### PR TITLE
Fix popgen links (attempt #2)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,7 +11,7 @@ assignees: ''
 A clear and concise description of what the bug is, and what you instead expect to be happening
 
 **Link to page(s) where bug is occurring**
-https://seqr.broadinstitute.org/...
+https://seqr.populationgenomics.org.au/...
 
 **Scope of the bug**
 Are you experiencing this issue in all projects? Within specific families within one project?

--- a/INCIDENTS.md
+++ b/INCIDENTS.md
@@ -1,7 +1,7 @@
 ## Active seqr incidents
 
 There are currently no known seqr incidents. 
-If you are experiencing any difficulties, email seqr@populationgenomics.org.au or submit a [github issue](https://github.com/broadinstitute/seqr/issues)
+If you are experiencing any difficulties, email seqr@populationgenomics.org.au or submit a [github issue](https://github.com/populationgenomics/seqr/issues)
 
 ## Past seqr incidents
 

--- a/INCIDENTS.md
+++ b/INCIDENTS.md
@@ -5,6 +5,5 @@ If you are experiencing any difficulties, email seqr@populationgenomics.org.au o
 
 ## Past seqr incidents
 
-Known, resolved incidents that occured on the Broad's seqr deployment (https://seqr.broadinstitute.org/): 
-- 4/7/2020: seqr down after error on kubernetes redeployment
-- 3/11/2020: seqr down after error on kubernetes redeployment
+Known, resolved incidents that occured on the Broad's seqr deployment (https://seqr.populationgenomics.org.au/): 
+- 

--- a/INCIDENTS.md
+++ b/INCIDENTS.md
@@ -1,7 +1,7 @@
 ## Active seqr incidents
 
 There are currently no known seqr incidents. 
-If you are experiencing any difficulties, email seqr@broadinstitute.org or submit a [github issue](https://github.com/broadinstitute/seqr/issues)
+If you are experiencing any difficulties, email seqr@populationgenomics.org.au or submit a [github issue](https://github.com/broadinstitute/seqr/issues)
 
 ## Past seqr incidents
 

--- a/deploy/LOCAL_INSTALL.md
+++ b/deploy/LOCAL_INSTALL.md
@@ -27,7 +27,7 @@ The steps below describe how to create a new empty seqr instance with a single A
 ```
 SEQR_DIR=$(pwd)
 
-wget https://raw.githubusercontent.com/broadinstitute/seqr/master/docker-compose.yml
+wget https://raw.githubusercontent.com/populationgenomics/seqr/master/docker-compose.yml
 
 docker-compose up -d seqr   # start up the seqr docker image in the background after also starting other components it depends on (postgres, redis, elasticsearch). This may take 10+ minutes.
 docker-compose logs -f seqr  # (optional) continuously print seqr logs to see when it is done starting up or if there are any errors. Type Ctrl-C to exit from the logs. 
@@ -59,7 +59,7 @@ The steps below describe how to annotate a callset and then load it into your on
    ```
    SEQR_DIR=$(pwd)
    
-   wget https://raw.githubusercontent.com/broadinstitute/seqr/master/docker-compose.yml
+   wget https://raw.githubusercontent.com/populationgenomics/seqr/master/docker-compose.yml
    
    docker-compose up -d pipeline-runner            # start the pipeline-runner container 
    docker-compose exec pipeline-runner /bin/bash   # open a shell inside the pipeline-runner container (analogous to ssh'ing into a remote machine)
@@ -219,4 +219,4 @@ After the dataset is loaded into elasticsearch, it can be added to your seqr pro
 
 #### Enable read viewing in the browser (optional): 
 
-To make .bam/.cram files viewable in the browser through igv.js, see **[ReadViz Setup Instructions](https://github.com/broadinstitute/seqr/blob/master/deploy/READVIZ_SETUP.md)**      
+To make .bam/.cram files viewable in the browser through igv.js, see **[ReadViz Setup Instructions](https://github.com/populationgenomics/seqr/blob/master/deploy/READVIZ_SETUP.md)**      

--- a/deploy/MIGRATE.md
+++ b/deploy/MIGRATE.md
@@ -6,7 +6,7 @@ This README describes steps for migrating an older seqr instance.
    pg_dump -U postgres seqrdb | gzip -c - > backup.gz
    ```
 
-2. Download or clone the lastest seqr code from [https://github.com/broadinstitute/seqr](https://github.com/broadinstitute/seqr)
+2. Download or clone the lastest seqr code from [https://github.com/populationgenomics/seqr](https://github.com/populationgenomics/seqr)
 
 3. Run migrations:
    ```

--- a/deploy/READVIZ_SETUP.md
+++ b/deploy/READVIZ_SETUP.md
@@ -5,7 +5,7 @@ for individual variants to be viewed in the browser using [IGV.js](https://githu
 If your read files are located on the machine that's running the seqr application server, these steps will enable
 viewing this read data through IGV.js:
 
-1) When running seqr using docker-compose (as [described here](https://github.com/broadinstitute/seqr/blob/master/deploy/LOCAL_INSTALL.md)), 
+1) When running seqr using docker-compose (as [described here](https://github.com/populationgenomics/seqr/blob/master/deploy/LOCAL_INSTALL.md)), 
 place the bam/cram and index files in the `./data/readviz/` sub-directory that was created under the directory containing
 the docker-compose.yml file. When you start seqr, docker-compose will mount the `./data/readviz/` directory to a `/readviz`
 top-level directory inside the seqr container.

--- a/matchmaker/migrations/0001_initial.py
+++ b/matchmaker/migrations/0001_initial.py
@@ -165,7 +165,7 @@ class Migration(migrations.Migration):
                 ('submission_id', models.CharField(db_index=True, max_length=255, unique=True)),
                 ('label', models.CharField(blank=True, max_length=255, null=True)),
                 ('contact_name', models.TextField(default='Samantha Baxter')),
-                ('contact_href', models.TextField(default='mailto:matchmaker@broadinstitute.org')),
+                ('contact_href', models.TextField(default='mailto:matchmaker@populationgenomics.org.au')),
                 ('features', django.contrib.postgres.fields.jsonb.JSONField(null=True)),
                 ('genomic_features', django.contrib.postgres.fields.jsonb.JSONField(null=True)),
                 ('deleted_date', models.DateTimeField(null=True)),

--- a/matchmaker/views/external_api.py
+++ b/matchmaker/views/external_api.py
@@ -208,5 +208,5 @@ matchbox on {insertion_date}, with seqr link
 
 MME_EMAIL_FOOTER = """
 Thank you for using the matchbox system for the Matchmaker Exchange at the Broad Center for Mendelian Genomics. 
-Our website can be found at https://seqr.broadinstitute.org/matchmaker/matchbox and our legal disclaimers can 
-be found found at https://seqr.broadinstitute.org/matchmaker/disclaimer"""
+Our website can be found at https://seqr.populationgenomics.org.au/matchmaker/matchbox and our legal disclaimers can 
+be found found at https://seqr.populationgenomics.org.au/matchmaker/disclaimer"""

--- a/matchmaker/views/external_api_tests.py
+++ b/matchmaker/views/external_api_tests.py
@@ -164,7 +164,7 @@ class ExternalAPITest(TestCase):
                 'id': 'P0004515',
                 'label': 'P0004515',
                 'contact': {
-                    'href': 'mailto:UDNCC@hms.harvard.edu,matchmaker@phenomecentral.org',
+                    'href': 'mailto:seqr+udncc@populationgenomics.org.au,matchmaker+phenomecentral@populationgenomics.org.au',
                     'name': 'Baylor UDN Clinical Site',
                     'institution': 'Broad Center for Mendelian Genomics',
                 },
@@ -230,7 +230,7 @@ be found found at https://seqr.broadinstitute.org/matchmaker/disclaimer."""
 
         mock_post_to_slack.assert_called_with('matchmaker_matches', message_template.format(
             matches='{}\n{}'.format(match1, match2),
-            emails='UDNCC@hms.harvard.edu, matchmaker@phenomecentral.org, seqr+test_user@populationgenomics.org.au'
+            emails='seqr+udncc@populationgenomics.org.au, matchmaker+phenomecentral@populationgenomics.org.au, seqr+test_user@populationgenomics.org.au'
         ))
 
         mock_email.assert_has_calls([
@@ -243,8 +243,8 @@ be found found at https://seqr.broadinstitute.org/matchmaker/disclaimer."""
             mock.call().send(),
             mock.call(
                 subject='Received new MME match',
-                body=message_template.format(matches=match2, emails='UDNCC@hms.harvard.edu, matchmaker@phenomecentral.org'),
-                to=['UDNCC@hms.harvard.edu', 'matchmaker@phenomecentral.org'],
+                body=message_template.format(matches=match2, emails='seqr+udncc@populationgenomics.org.au, matchmaker+phenomecentral@populationgenomics.org.au'),
+                to=['seqr+udncc@populationgenomics.org.au', 'matchmaker+phenomecentral@populationgenomics.org.au'],
                 from_email='matchmaker@populationgenomics.org.au',
             ),
             mock.call().send()])

--- a/matchmaker/views/external_api_tests.py
+++ b/matchmaker/views/external_api_tests.py
@@ -116,7 +116,7 @@ class ExternalAPITest(TestCase):
                 'id': 'NA19675_1_01',
                 'label': 'NA19675_1',
                 'contact': {
-                    'href': 'mailto:matchmaker@broadinstitute.org,test_user@broadinstitute.org',
+                    'href': 'mailto:matchmaker@populationgenomics.org.au,test_user@broadinstitute.org',
                     'name': 'Sam Baxter',
                     'institution': 'Broad Center for Mendelian Genomics',
                 },
@@ -238,14 +238,14 @@ be found found at https://seqr.broadinstitute.org/matchmaker/disclaimer."""
                 subject='Received new MME match',
                 body=message_template.format(matches=match1, emails='test_user@broadinstitute.org'),
                 to=['test_user@broadinstitute.org'],
-                from_email='matchmaker@broadinstitute.org',
+                from_email='matchmaker@populationgenomics.org.au',
             ),
             mock.call().send(),
             mock.call(
                 subject='Received new MME match',
                 body=message_template.format(matches=match2, emails='UDNCC@hms.harvard.edu, matchmaker@phenomecentral.org'),
                 to=['UDNCC@hms.harvard.edu', 'matchmaker@phenomecentral.org'],
-                from_email='matchmaker@broadinstitute.org',
+                from_email='matchmaker@populationgenomics.org.au',
             ),
             mock.call().send()])
 

--- a/matchmaker/views/external_api_tests.py
+++ b/matchmaker/views/external_api_tests.py
@@ -116,7 +116,7 @@ class ExternalAPITest(TestCase):
                 'id': 'NA19675_1_01',
                 'label': 'NA19675_1',
                 'contact': {
-                    'href': 'mailto:matchmaker@populationgenomics.org.au,test_user@broadinstitute.org',
+                    'href': 'mailto:matchmaker@populationgenomics.org.au,seqr+test_user@populationgenomics.org.au',
                     'name': 'Sam Baxter',
                     'institution': 'Broad Center for Mendelian Genomics',
                 },
@@ -230,14 +230,14 @@ be found found at https://seqr.broadinstitute.org/matchmaker/disclaimer."""
 
         mock_post_to_slack.assert_called_with('matchmaker_matches', message_template.format(
             matches='{}\n{}'.format(match1, match2),
-            emails='UDNCC@hms.harvard.edu, matchmaker@phenomecentral.org, test_user@broadinstitute.org'
+            emails='UDNCC@hms.harvard.edu, matchmaker@phenomecentral.org, seqr+test_user@populationgenomics.org.au'
         ))
 
         mock_email.assert_has_calls([
             mock.call(
                 subject='Received new MME match',
-                body=message_template.format(matches=match1, emails='test_user@broadinstitute.org'),
-                to=['test_user@broadinstitute.org'],
+                body=message_template.format(matches=match1, emails='seqr+test_user@populationgenomics.org.au'),
+                to=['seqr+test_user@populationgenomics.org.au'],
                 from_email='matchmaker@populationgenomics.org.au',
             ),
             mock.call().send(),

--- a/matchmaker/views/external_api_tests.py
+++ b/matchmaker/views/external_api_tests.py
@@ -223,8 +223,8 @@ class ExternalAPITest(TestCase):
     We sent this email alert to: {emails}
 
 Thank you for using the matchbox system for the Matchmaker Exchange at the Broad Center for Mendelian Genomics. 
-Our website can be found at https://seqr.broadinstitute.org/matchmaker/matchbox and our legal disclaimers can 
-be found found at https://seqr.broadinstitute.org/matchmaker/disclaimer."""
+Our website can be found at https://seqr.populationgenomics.org.au/matchmaker/matchbox and our legal disclaimers can 
+be found found at https://seqr.populationgenomics.org.au/matchmaker/disclaimer."""
         match1 = 'seqr ID NA19675_1 from project 1kg project n\u00e5me with uni\u00e7\u00f8de in family 1 inserted into matchbox on May 23, 2018, with seqr link /project/R0001_1kg/family_page/F000001_1/matchmaker_exchange'
         match2 = 'seqr ID NA20888 from project Test Reprocessed Project in family 12 inserted into matchbox on Feb 05, 2019, with seqr link /project/R0003_test/family_page/F000012_12/matchmaker_exchange'
 

--- a/matchmaker/views/external_api_tests.py
+++ b/matchmaker/views/external_api_tests.py
@@ -230,7 +230,7 @@ be found found at https://seqr.populationgenomics.org.au/matchmaker/disclaimer."
 
         mock_post_to_slack.assert_called_with('matchmaker_matches', message_template.format(
             matches='{}\n{}'.format(match1, match2),
-            emails='seqr+udncc@populationgenomics.org.au, matchmaker+phenomecentral@populationgenomics.org.au, seqr+test_user@populationgenomics.org.au'
+            emails='matchmaker+phenomecentral@populationgenomics.org.au, seqr+test_user@populationgenomics.org.au, seqr+udncc@populationgenomics.org.au'
         ))
 
         mock_email.assert_has_calls([

--- a/matchmaker/views/matchmaker_api_tests.py
+++ b/matchmaker/views/matchmaker_api_tests.py
@@ -200,7 +200,7 @@ class MatchmakerAPITest(AuthenticationTestCase):
             'lastModifiedDate': '2018-05-23T09:07:49.719Z',
             'deletedDate': None,
             'contactName': 'Sam Baxter',
-            'contactHref': 'mailto:matchmaker@populationgenomics.org.au,test_user@broadinstitute.org',
+            'contactHref': 'mailto:matchmaker@populationgenomics.org.au,seqr+test_user@populationgenomics.org.au',
             'submissionId': 'NA19675_1_01',
             'phenotypes': [
                 {'id': 'HP:0001252', 'label': 'Muscular hypotonia', 'observed': 'yes'},
@@ -319,7 +319,7 @@ class MatchmakerAPITest(AuthenticationTestCase):
             'lastModifiedDate': '2018-05-23T09:07:49.719Z',
             'deletedDate': None,
             'contactName': 'Sam Baxter',
-            'contactHref': 'mailto:matchmaker@populationgenomics.org.au,test_user@broadinstitute.org',
+            'contactHref': 'mailto:matchmaker@populationgenomics.org.au,seqr+test_user@populationgenomics.org.au',
             'submissionId': 'NA19675_1_01',
             'phenotypes': [
                 {'id': 'HP:0001252', 'label': 'Muscular hypotonia', 'observed': 'yes'},
@@ -360,7 +360,7 @@ class MatchmakerAPITest(AuthenticationTestCase):
                 'id': 'NA19675_1_01',
                 'label': 'NA19675_1',
                 'contact': {
-                    'href': 'mailto:matchmaker@populationgenomics.org.au,test_user@broadinstitute.org',
+                    'href': 'mailto:matchmaker@populationgenomics.org.au,seqr+test_user@populationgenomics.org.au',
                     'name': 'Sam Baxter',
                     'institution': 'Broad Center for Mendelian Genomics',
                 },
@@ -423,7 +423,7 @@ class MatchmakerAPITest(AuthenticationTestCase):
         mock_email.assert_called_with(
             subject='New matches found for MME submission NA19675_1 (project: 1kg project n\xe5me with uni\xe7\xf8de)',
             body=message,
-            to=['test_user@broadinstitute.org'],
+            to=['seqr+test_user@populationgenomics.org.au'],
             from_email='matchmaker@populationgenomics.org.au')
         mock_email.return_value.send.assert_called()
 
@@ -779,7 +779,7 @@ class MatchmakerAPITest(AuthenticationTestCase):
             'lastModifiedDate': mock.ANY,
             'deletedDate': None,
             'contactName': 'Sam Baxter',
-            'contactHref': 'mailto:matchmaker@populationgenomics.org.au,test_user@broadinstitute.org',
+            'contactHref': 'mailto:matchmaker@populationgenomics.org.au,seqr+test_user@populationgenomics.org.au',
             'submissionId': 'NA19675_1_01',
             'phenotypes': [],
             'geneVariants': [{'geneId': 'ENSG00000235249'}],

--- a/matchmaker/views/matchmaker_api_tests.py
+++ b/matchmaker/views/matchmaker_api_tests.py
@@ -58,7 +58,7 @@ PARSED_RESULT = {
             {'gene': {'id': 'DDX11L1'}},
         ],
         'contact': {
-            'href': 'mailto:UDNCC@hms.harvard.edu,matchmaker@phenomecentral.org',
+            'href': 'mailto:seqr+udncc@populationgenomics.org.au,matchmaker+phenomecentral@populationgenomics.org.au',
             'name': 'Baylor UDN Clinical Site'
         },
         'id': 'P0004515',

--- a/matchmaker/views/matchmaker_api_tests.py
+++ b/matchmaker/views/matchmaker_api_tests.py
@@ -21,7 +21,7 @@ RESULT_STATUS_GUID = 'MR0003552_SHE_1006P_1'
 
 SUBMISSION_DATA = {
     'individualGuid': NO_SUBMISSION_INDIVIDUAL_GUID,
-    'contactHref': 'mailto:test@broadinstitute.org',
+    'contactHref': 'mailto:seqr+test@populationgenomics.org.au',
     'contactName': 'PI',
     'phenotypes': [
         {'id': 'HP:0012469', 'label': 'Infantile spasms', 'observed': 'yes'}
@@ -487,7 +487,7 @@ class MatchmakerAPITest(AuthenticationTestCase):
             'lastModifiedDate': mock.ANY,
             'deletedDate': None,
             'contactName': 'PI',
-            'contactHref': 'mailto:test@broadinstitute.org',
+            'contactHref': 'mailto:seqr+test@populationgenomics.org.au',
             'submissionId': NO_SUBMISSION_INDIVIDUAL_GUID,
             'phenotypes': [
                 {'id': 'HP:0012469', 'label': 'Infantile spasms', 'observed': 'yes'}
@@ -533,7 +533,7 @@ class MatchmakerAPITest(AuthenticationTestCase):
             'patient': {
                 'id': NO_SUBMISSION_INDIVIDUAL_GUID,
                 'label': 'HG00733',
-                'contact': {'href': 'mailto:test@broadinstitute.org', 'name': 'PI',
+                'contact': {'href': 'mailto:seqr+test@populationgenomics.org.au', 'name': 'PI',
                             'institution': 'Broad Center for Mendelian Genomics'},
                 'sex': 'FEMALE',
                 'species': 'NCBITaxon:9606',

--- a/matchmaker/views/matchmaker_api_tests.py
+++ b/matchmaker/views/matchmaker_api_tests.py
@@ -200,7 +200,7 @@ class MatchmakerAPITest(AuthenticationTestCase):
             'lastModifiedDate': '2018-05-23T09:07:49.719Z',
             'deletedDate': None,
             'contactName': 'Sam Baxter',
-            'contactHref': 'mailto:matchmaker@broadinstitute.org,test_user@broadinstitute.org',
+            'contactHref': 'mailto:matchmaker@populationgenomics.org.au,test_user@broadinstitute.org',
             'submissionId': 'NA19675_1_01',
             'phenotypes': [
                 {'id': 'HP:0001252', 'label': 'Muscular hypotonia', 'observed': 'yes'},
@@ -319,7 +319,7 @@ class MatchmakerAPITest(AuthenticationTestCase):
             'lastModifiedDate': '2018-05-23T09:07:49.719Z',
             'deletedDate': None,
             'contactName': 'Sam Baxter',
-            'contactHref': 'mailto:matchmaker@broadinstitute.org,test_user@broadinstitute.org',
+            'contactHref': 'mailto:matchmaker@populationgenomics.org.au,test_user@broadinstitute.org',
             'submissionId': 'NA19675_1_01',
             'phenotypes': [
                 {'id': 'HP:0001252', 'label': 'Muscular hypotonia', 'observed': 'yes'},
@@ -360,7 +360,7 @@ class MatchmakerAPITest(AuthenticationTestCase):
                 'id': 'NA19675_1_01',
                 'label': 'NA19675_1',
                 'contact': {
-                    'href': 'mailto:matchmaker@broadinstitute.org,test_user@broadinstitute.org',
+                    'href': 'mailto:matchmaker@populationgenomics.org.au,test_user@broadinstitute.org',
                     'name': 'Sam Baxter',
                     'institution': 'Broad Center for Mendelian Genomics',
                 },
@@ -424,7 +424,7 @@ class MatchmakerAPITest(AuthenticationTestCase):
             subject='New matches found for MME submission NA19675_1 (project: 1kg project n\xe5me with uni\xe7\xf8de)',
             body=message,
             to=['test_user@broadinstitute.org'],
-            from_email='matchmaker@broadinstitute.org')
+            from_email='matchmaker@populationgenomics.org.au')
         mock_email.return_value.send.assert_called()
 
         # Test new result model created
@@ -573,7 +573,7 @@ class MatchmakerAPITest(AuthenticationTestCase):
         url = reverse(update_mme_submission, args=[new_submission_guid])
         update_body = {
             'individualGuid': NO_SUBMISSION_INDIVIDUAL_GUID,
-            'contactHref': 'mailto:matchmaker@broadinstitute.org',
+            'contactHref': 'mailto:matchmaker@populationgenomics.org.au',
             'contactName': 'Test Name',
             'phenotypes': [
                 {'id': 'HP:0012469', 'label': 'Infantile spasms', 'observed': 'no'},
@@ -624,7 +624,7 @@ class MatchmakerAPITest(AuthenticationTestCase):
                     }
                 ],
                 'contact': {
-                    'href': 'mailto:matchmaker@broadinstitute.org',
+                    'href': 'mailto:matchmaker@populationgenomics.org.au',
                     'name': 'Sam Baxter',
                     'institution': 'Broad Center for Mendelian Genomics'
                 },
@@ -682,7 +682,7 @@ class MatchmakerAPITest(AuthenticationTestCase):
             'lastModifiedDate': mock.ANY,
             'deletedDate': None,
             'contactName': 'Test Name',
-            'contactHref': 'mailto:matchmaker@broadinstitute.org',
+            'contactHref': 'mailto:matchmaker@populationgenomics.org.au',
             'submissionId': NO_SUBMISSION_INDIVIDUAL_GUID,
             'phenotypes': [
                 {'id': 'HP:0012469', 'label': 'Infantile spasms', 'observed': 'no'},
@@ -714,7 +714,7 @@ class MatchmakerAPITest(AuthenticationTestCase):
             'patient': {
                 'id': NO_SUBMISSION_INDIVIDUAL_GUID,
                 'label': 'HG00733',
-                'contact': {'href': 'mailto:matchmaker@broadinstitute.org', 'name': 'Test Name',
+                'contact': {'href': 'mailto:matchmaker@populationgenomics.org.au', 'name': 'Test Name',
                             'institution': 'Broad Center for Mendelian Genomics'},
                 'species': 'NCBITaxon:9606',
                 'sex': 'FEMALE',
@@ -779,7 +779,7 @@ class MatchmakerAPITest(AuthenticationTestCase):
             'lastModifiedDate': mock.ANY,
             'deletedDate': None,
             'contactName': 'Sam Baxter',
-            'contactHref': 'mailto:matchmaker@broadinstitute.org,test_user@broadinstitute.org',
+            'contactHref': 'mailto:matchmaker@populationgenomics.org.au,test_user@broadinstitute.org',
             'submissionId': 'NA19675_1_01',
             'phenotypes': [],
             'geneVariants': [{'geneId': 'ENSG00000235249'}],
@@ -849,7 +849,7 @@ class MatchmakerAPITest(AuthenticationTestCase):
             subject='some email subject',
             body='some email content',
             to=['test@test.com', 'other_test@gmail.com'],
-            from_email='matchmaker@broadinstitute.org')
+            from_email='matchmaker@populationgenomics.org.au')
         mock_email.return_value.send.assert_called()
 
         mock_email.return_value.send.side_effect = EmailException()

--- a/seqr/fixtures/1kg_project.json
+++ b/seqr/fixtures/1kg_project.json
@@ -17,7 +17,7 @@
 	"is_mme_enabled": true,
     "has_case_review": true,
 	"mme_primary_data_owner": "PI",
-    "mme_contact_url": "mailto:test@broadinstitute.org,matchmaker@populationgenomics.org.au",
+    "mme_contact_url": "mailto:seqr+test@populationgenomics.org.au,matchmaker@populationgenomics.org.au",
 	"last_accessed_date": "2017-09-15T18:15:50.827Z"
     }
 },
@@ -54,7 +54,7 @@
     "workspace_namespace": "my-seqr-billing",
 	"is_mme_enabled": false,
 	"mme_primary_data_owner": "",
-    "mme_contact_url": "mailto:seqr-test@gmail.com,test@broadinstitute.org",
+    "mme_contact_url": "mailto:seqr-test@gmail.com,seqr+test@populationgenomics.org.au",
 	"last_accessed_date": "2017-09-15T18:15:50.827Z"
     }
 },

--- a/seqr/fixtures/1kg_project.json
+++ b/seqr/fixtures/1kg_project.json
@@ -17,7 +17,7 @@
 	"is_mme_enabled": true,
     "has_case_review": true,
 	"mme_primary_data_owner": "PI",
-    "mme_contact_url": "mailto:test@broadinstitute.org,matchmaker@broadinstitute.org",
+    "mme_contact_url": "mailto:test@broadinstitute.org,matchmaker@populationgenomics.org.au",
 	"last_accessed_date": "2017-09-15T18:15:50.827Z"
     }
 },
@@ -1912,7 +1912,7 @@
         "submission_id": "NA19675_1_01",
         "label": "NA19675_1",
         "contact_name": "Sam Baxter",
-        "contact_href": "mailto:matchmaker@broadinstitute.org,test_user@broadinstitute.org",
+        "contact_href": "mailto:matchmaker@populationgenomics.org.au,test_user@broadinstitute.org",
         "features": [
             {
                 "id": "HP:0001252",
@@ -1956,7 +1956,7 @@
         "submission_id": "NA20885",
         "label": "NA20885",
         "contact_name": "Sam Baxter",
-        "contact_href": "mailto:matchmaker@broadinstitute.org",
+        "contact_href": "mailto:matchmaker@populationgenomics.org.au",
         "features": [
             {
                 "id": "HP:0001252",
@@ -2037,7 +2037,7 @@
         "submission_id": "P0004517",
         "label": "P0004517",
        "contact_name": "Sam Baxter",
-        "contact_href": "mailto:matchmaker@broadinstitute.org",
+        "contact_href": "mailto:matchmaker@populationgenomics.org.au",
         "genomic_features": [
             {
                 "gene": {

--- a/seqr/fixtures/1kg_project.json
+++ b/seqr/fixtures/1kg_project.json
@@ -1912,7 +1912,7 @@
         "submission_id": "NA19675_1_01",
         "label": "NA19675_1",
         "contact_name": "Sam Baxter",
-        "contact_href": "mailto:matchmaker@populationgenomics.org.au,test_user@broadinstitute.org",
+        "contact_href": "mailto:matchmaker@populationgenomics.org.au,seqr+test_user@populationgenomics.org.au",
         "features": [
             {
                 "id": "HP:0001252",

--- a/seqr/fixtures/1kg_project.json
+++ b/seqr/fixtures/1kg_project.json
@@ -1998,7 +1998,7 @@
         "submission_id": "P0004515",
         "label": "P0004515",
         "contact_name": "Baylor UDN Clinical Site",
-        "contact_href": "mailto:UDNCC@hms.harvard.edu,matchmaker@phenomecentral.org",
+        "contact_href": "mailto:seqr+udncc@populationgenomics.org.au,matchmaker+phenomecentral@populationgenomics.org.au",
         "genomic_features": [
             {
                 "gene": {
@@ -2080,7 +2080,7 @@
                     }
                 ],
                 "contact": {
-                    "href": "mailto:UDNCC@hms.harvard.edu,matchmaker@phenomecentral.org",
+                    "href": "mailto:seqr+udncc@populationgenomics.org.au,matchmaker+phenomecentral@populationgenomics.org.au",
                     "name": "Baylor UDN Clinical Site"
                 },
                 "id": "P0004515",

--- a/seqr/fixtures/social_auth.json
+++ b/seqr/fixtures/social_auth.json
@@ -5,7 +5,7 @@
     "fields": {
         "user": 10,
         "provider": "google-oauth2",
-        "uid": "test_user@broadinstitute.org",
+        "uid": "seqr+test_user@populationgenomics.org.au",
         "extra_data": "{\"expires\": 3599, \"auth_time\": 1603287741, \"token_type\": \"Bearer\", \"access_token\": \"ya29.EXAMPLE\"}",
         "created": "2020-03-12T23:09:54.180Z",
         "modified": "2020-03-12T23:09:54.180Z"

--- a/seqr/fixtures/users.json
+++ b/seqr/fixtures/users.json
@@ -41,7 +41,7 @@
         "username": "test_user",
         "first_name": "Test User",
         "last_name": "",
-        "email": "test_user@broadinstitute.org",
+        "email": "seqr+test_user@populationgenomics.org.au",
         "is_staff": false,
         "is_active": true,
         "date_joined": "2017-03-12T23:09:54.180Z",

--- a/seqr/management/tests/update_mme_contact_tests.py
+++ b/seqr/management/tests/update_mme_contact_tests.py
@@ -17,7 +17,7 @@ class TransferFamiliesTest(TestCase):
         self.assertEqual(str(err.exception), 'Error: the following arguments are required: email')
 
         call_command(
-            'update_mme_contact', 'UDNCC@hms.harvard.edu', '--replace-email', 'test_user@broadinstitute.org',
+            'update_mme_contact', 'UDNCC@hms.harvard.edu', '--replace-email', 'seqr+test_user@populationgenomics.org.au',
         )
         mock_logger.assert_has_calls([
             mock.call('Updating 1 submissions'),
@@ -25,11 +25,11 @@ class TransferFamiliesTest(TestCase):
         ])
         self.assertEqual(
             MatchmakerSubmission.objects.get(id=3).contact_href,
-            'mailto:test_user@broadinstitute.org,matchmaker@phenomecentral.org',
+            'mailto:seqr+test_user@populationgenomics.org.au,matchmaker@phenomecentral.org',
         )
 
         mock_logger.reset_mock()
-        call_command('update_mme_contact', 'test_user@broadinstitute.org')
+        call_command('update_mme_contact', 'seqr+test_user@populationgenomics.org.au')
         mock_logger.assert_has_calls([
             mock.call('Updating 2 submissions'),
             mock.call('Done'),

--- a/seqr/management/tests/update_mme_contact_tests.py
+++ b/seqr/management/tests/update_mme_contact_tests.py
@@ -35,5 +35,5 @@ class TransferFamiliesTest(TestCase):
             mock.call('Done'),
         ])
         self.assertEqual( MatchmakerSubmission.objects.get(id=3).contact_href, 'mailto:matchmaker@phenomecentral.org')
-        self.assertEqual(MatchmakerSubmission.objects.get(id=1).contact_href, 'mailto:matchmaker@broadinstitute.org')
+        self.assertEqual(MatchmakerSubmission.objects.get(id=1).contact_href, 'mailto:matchmaker@populationgenomics.org.au')
 

--- a/seqr/management/tests/update_mme_contact_tests.py
+++ b/seqr/management/tests/update_mme_contact_tests.py
@@ -17,7 +17,7 @@ class TransferFamiliesTest(TestCase):
         self.assertEqual(str(err.exception), 'Error: the following arguments are required: email')
 
         call_command(
-            'update_mme_contact', 'UDNCC@hms.harvard.edu', '--replace-email', 'seqr+test_user@populationgenomics.org.au',
+            'update_mme_contact', 'seqr+udncc@populationgenomics.org.au', '--replace-email', 'seqr+test_user@populationgenomics.org.au',
         )
         mock_logger.assert_has_calls([
             mock.call('Updating 1 submissions'),
@@ -25,7 +25,7 @@ class TransferFamiliesTest(TestCase):
         ])
         self.assertEqual(
             MatchmakerSubmission.objects.get(id=3).contact_href,
-            'mailto:seqr+test_user@populationgenomics.org.au,matchmaker@phenomecentral.org',
+            'mailto:seqr+test_user@populationgenomics.org.au,matchmaker+phenomecentral@populationgenomics.org.au',
         )
 
         mock_logger.reset_mock()
@@ -34,6 +34,6 @@ class TransferFamiliesTest(TestCase):
             mock.call('Updating 2 submissions'),
             mock.call('Done'),
         ])
-        self.assertEqual( MatchmakerSubmission.objects.get(id=3).contact_href, 'mailto:matchmaker@phenomecentral.org')
+        self.assertEqual( MatchmakerSubmission.objects.get(id=3).contact_href, 'mailto:matchmaker+phenomecentral@populationgenomics.org.au')
         self.assertEqual(MatchmakerSubmission.objects.get(id=1).contact_href, 'mailto:matchmaker@populationgenomics.org.au')
 

--- a/seqr/migrations/0001_squashed_0067_remove_project_custom_reference_populations.py
+++ b/seqr/migrations/0001_squashed_0067_remove_project_custom_reference_populations.py
@@ -83,7 +83,7 @@ class Migration(migrations.Migration):
                 ('owners_group',
                  models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, related_name='+', to='auth.Group')),
                 ('mme_contact_url', models.TextField(
-                    blank=True, default='mailto:matchmaker@broadinstitute.org', null=True)),
+                    blank=True, default='mailto:matchmaker@populationgenomics.org.au', null=True)),
                 ('mme_contact_institution', models.TextField(
                     blank=True, default='Broad Center for Mendelian Genomics', null=True)),
                 ('disease_area', models.CharField(blank=True, choices=[

--- a/seqr/views/apis/family_api_tests.py
+++ b/seqr/views/apis/family_api_tests.py
@@ -164,7 +164,7 @@ class FamilyAPITest(AuthenticationTestCase):
         response_json = response.json()
 
         self.assertListEqual(list(response_json.keys()), [FAMILY_GUID])
-        self.assertEqual(response_json[FAMILY_GUID]['assignedAnalyst']['email'], 'test_user@broadinstitute.org')
+        self.assertEqual(response_json[FAMILY_GUID]['assignedAnalyst']['email'], 'seqr+test_user@populationgenomics.org.au')
         self.assertEqual(response_json[FAMILY_GUID]['assignedAnalyst']['fullName'], 'Test User')
 
         # unassign analyst

--- a/seqr/views/apis/report_api.py
+++ b/seqr/views/apis/report_api.py
@@ -535,7 +535,7 @@ def _get_sample_airtable_metadata(sample_ids, user, include_collaborator=False):
 
 
 def _validate_airtable_access(user):
-    if not (is_google_authenticated(user) and user.email.endswith('broadinstitute.org')):
+    if not (is_google_authenticated(user) and user.email.endswith('populationgenomics.org.au')):
         raise PermissionDenied('Error: To access airtable user must login with Google authentication.')
 
 

--- a/seqr/views/apis/users_api_tests.py
+++ b/seqr/views/apis/users_api_tests.py
@@ -221,7 +221,7 @@ class UsersAPITest(object):
 
         # Send valid request
         response = self.client.post(url, content_type='application/json', data=json.dumps({
-            'email': 'test_user@broadinstitute.org'
+            'email': 'seqr+test_user@populationgenomics.org.au'
         }))
         self.assertEqual(response.status_code, 200)
 
@@ -235,14 +235,14 @@ class UsersAPITest(object):
             'Reset your seqr password',
             expected_email_content,
             None,
-            ['test_user@broadinstitute.org'],
+            ['seqr+test_user@populationgenomics.org.au'],
             fail_silently=False,
         )
 
         # Test email failure
         mock_send_mail.side_effect = AnymailError('Connection err')
         response = self.client.post(url, content_type='application/json', data=json.dumps({
-            'email': 'test_user@broadinstitute.org'
+            'email': 'seqr+test_user@populationgenomics.org.au'
         }))
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.reason_phrase, 'Connection err')

--- a/settings.py
+++ b/settings.py
@@ -299,7 +299,7 @@ REDIS_SERVICE_HOSTNAME = os.environ.get('REDIS_SERVICE_HOSTNAME', 'localhost')
 # Matchmaker
 MME_DEFAULT_CONTACT_NAME = 'Samantha Baxter'
 MME_DEFAULT_CONTACT_INSTITUTION = 'Broad Center for Mendelian Genomics'
-MME_DEFAULT_CONTACT_EMAIL = 'matchmaker@broadinstitute.org'
+MME_DEFAULT_CONTACT_EMAIL = 'matchmaker@populationgenomics.org.au'
 MME_DEFAULT_CONTACT_HREF = 'mailto:{}'.format(MME_DEFAULT_CONTACT_EMAIL)
 
 MME_CONFIG_DIR = os.environ.get('MME_CONFIG_DIR', '')

--- a/ui/package.json
+++ b/ui/package.json
@@ -203,7 +203,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/broadinstitute/seqr.git"
+    "url": "git+https://github.com/populationgenomics/seqr.git"
   },
   "license": "AGPL-3.0"
 }

--- a/ui/pages/AnvilWorkspace/components/LoadWorkspaceDataForm.jsx
+++ b/ui/pages/AnvilWorkspace/components/LoadWorkspaceDataForm.jsx
@@ -120,7 +120,7 @@ const LoadWorkspaceDataForm = React.memo(({ namespace, name }) =>
     />
     <p>
       Need help? please submit &nbsp;
-      <a href="https://github.com/broadinstitute/seqr/issues/new?labels=bug&template=bug_report.md">GitHub Issues</a>
+      <a href="https://github.com/populationgenomics/seqr/issues/new?labels=bug&template=bug_report.md">GitHub Issues</a>
       , &nbsp; or &nbsp;
       <a href="mailto:seqr@populationgenomics.org.au" target="_blank">
         Email Us

--- a/ui/pages/AnvilWorkspace/components/LoadWorkspaceDataForm.jsx
+++ b/ui/pages/AnvilWorkspace/components/LoadWorkspaceDataForm.jsx
@@ -122,7 +122,7 @@ const LoadWorkspaceDataForm = React.memo(({ namespace, name }) =>
       Need help? please submit &nbsp;
       <a href="https://github.com/broadinstitute/seqr/issues/new?labels=bug&template=bug_report.md">GitHub Issues</a>
       , &nbsp; or &nbsp;
-      <a href="mailto:seqr@broadinstitute.org" target="_blank">
+      <a href="mailto:seqr@populationgenomics.org.au" target="_blank">
         Email Us
       </a>
     </p>

--- a/ui/pages/Project/components/ProjectOverview.jsx
+++ b/ui/pages/Project/components/ProjectOverview.jsx
@@ -143,7 +143,7 @@ const ProjectOverview = React.memo((
                   <div>
                     Loading data from AnVIL to seqr is a slow process, and generally takes a week.
                     If you have been waiting longer than this for your data, please reach
-                    out to <a href="mailto:seqr@broadinstitute.org">seqr@broadinstitute.org</a>
+                    out to <a href="mailto:seqr@populationgenomics.org.au">seqr@populationgenomics.org.au</a>
                   </div>
                 }
               />

--- a/ui/pages/Project/fixtures.js
+++ b/ui/pages/Project/fixtures.js
@@ -328,7 +328,7 @@ export const STATE_WITH_2_FAMILIES = {
         {
           dateJoined: '2019-02-20T18:01:36.677Z',
           displayName: '',
-          email: 'test1@broadinstitute.org',
+          email: 'seqr+test1@populationgenomics.org.au',
           firstName: '',
           hasEditPermissions: true,
           hasViewPermissions: true,
@@ -341,7 +341,7 @@ export const STATE_WITH_2_FAMILIES = {
         {
           dateJoined: '2019-02-20T18:01:36.677Z',
           displayName: '',
-          email: 'test2@broadinstitute.org',
+          email: 'seqr+test2@populationgenomics.org.au',
           firstName: '',
           hasEditPermissions: true,
           hasViewPermissions: true,
@@ -965,7 +965,7 @@ export const STATE_WITH_2_FAMILIES = {
     },
     'test_user1': {
       displayName: '',
-      email: 'test1@broadinstitute.org',
+      email: 'seqr+test1@populationgenomics.org.au',
       firstName: '',
       isAnalyst: false,
       lastName: '',
@@ -973,7 +973,7 @@ export const STATE_WITH_2_FAMILIES = {
     },
     'test_user2': {
       displayName: '',
-      email: 'test2@broadinstitute.org',
+      email: 'seqr+test2@populationgenomics.org.au',
       firstName: '',
       isAnalyst: true,
       lastName: '',

--- a/ui/pages/Project/fixtures.js
+++ b/ui/pages/Project/fixtures.js
@@ -136,7 +136,7 @@ export const STATE1 = {
   },
   user: {
     date_joined: '2015-02-19T20:22:50.633Z',
-    email: 'test@broadinstitute.org',
+    email: 'seqr+test@populationgenomics.org.au',
     first_name: '',
     id: 1,
     is_active: true,
@@ -320,7 +320,7 @@ export const STATE_WITH_2_FAMILIES = {
       lastModifiedDate: '2017-03-14T17:37:32.712Z',
       mmePrimaryDataOwner: 'PI',
       mmeContactInstitution: 'Broad',
-      mmeContactUrl: 'test@broadinstitute.org',
+      mmeContactUrl: 'seqr+test@populationgenomics.org.au',
       name: '1000 Genomes Demo',
       projectCategoryGuids: [],
       projectGuid: 'R0237_1000_genomes_demo',
@@ -362,7 +362,7 @@ export const STATE_WITH_2_FAMILIES = {
   },
   user: {
     date_joined: '2015-02-19T20:22:50.633Z',
-    email: 'test@broadinstitute.org',
+    email: 'seqr+test@populationgenomics.org.au',
     first_name: '',
     id: 1,
     is_active: true,
@@ -957,7 +957,7 @@ export const STATE_WITH_2_FAMILIES = {
     },
     'test': {
       displayName: '',
-      email: 'test@broadinstitute.org',
+      email: 'seqr+test@populationgenomics.org.au',
       firName: '',
       isAnalyst: true,
       last_name: '',

--- a/ui/pages/Project/fixtures.js
+++ b/ui/pages/Project/fixtures.js
@@ -850,7 +850,7 @@ export const STATE_WITH_2_FAMILIES = {
       mmeResultGuids: ['MR0005038_HK018_0047','MR0004688_RGP_105_3'],
       createdDate: '2018-05-09T10:29:00.000Z',
       submissionId: 'NA19675_1',
-      contactHref: 'mailto:matchmaker@broadinstitute.org,test@test.com',
+      contactHref: 'mailto:matchmaker@populationgenomics.org.au,test@test.com',
       phenotypes: [
         {id: 'HP:0011405', label: 'Childhood onset short-limb short stature', observed: 'yes'},
         {id: "HP:0012638", label: "Abnormality of nervous system physiology", observed: "no"},

--- a/ui/pages/Project/selectors.js
+++ b/ui/pages/Project/selectors.js
@@ -406,7 +406,7 @@ export const getMmeDefaultContactEmail = createSelector(
 
     const contacts = [
       patient.contact.href.replace('mailto:', ''),
-      contactHref.replace('mailto:', '').replace('matchmaker@broadinstitute.org,', ''),
+      contactHref.replace('mailto:', '').replace('matchmaker@populationgenomics.org.au,', ''),
       user.email,
     ]
     return {

--- a/ui/pages/Project/selectors.test.js
+++ b/ui/pages/Project/selectors.test.js
@@ -92,7 +92,7 @@ test('getDefaultMmeSubmission', () => {
   const defaultSubmissions = getDefaultMmeSubmission(STATE_WITH_2_FAMILIES)
   expect(defaultSubmissions).toEqual({
     contactName: 'PI',
-    contactHref: 'test@broadinstitute.org',
+    contactHref: 'seqr+test@populationgenomics.org.au',
     geneVariants: [],
     phenotypes: [],
   })
@@ -115,7 +115,7 @@ test('getMmeDefaultContactEmail', () => {
   expect(getMmeDefaultContactEmail(STATE_WITH_2_FAMILIES, { matchmakerResultGuid: 'MR0005038_HK018_0047' })).toEqual({
     matchmakerResultGuid: 'MR0005038_HK018_0047',
     patientId: '12531',
-    to: 'crowley@unc.edu,test@test.com,test@broadinstitute.org',
+    to: 'crowley@unc.edu,test@test.com,seqr+test@populationgenomics.org.au',
     subject: 'OR2M3 Matchmaker Exchange connection (NA19675_1)',
     body: 'Dear James Crowley,\n\nWe recently matched with one of your patients in Matchmaker Exchange harboring variants in OR2M3. Our patient has a homozygous missense variant 1:248367227 TC>T, a copy number deletion 1:248367227-248369100 (CN=0) and presents with childhood onset short-limb short stature and flexion contracture. Would you be willing to share whether your patient\'s phenotype and genotype match with ours? We are very grateful for your help and look forward to hearing more.\n\nBest wishes,\nTest User',
   })

--- a/ui/pages/Public/LandingPage.jsx
+++ b/ui/pages/Public/LandingPage.jsx
@@ -55,11 +55,11 @@ export default () =>
             <List.Item>
               To get updates about seqr, &nbsp;
               <a target="_blank" href="http://groups.google.com/a/broadinstitute.org/forum/#!forum/seqr-updates/join">
-                <b>join our mailing list</b>
+                <b>join the Broad Institute's mailing list</b>
               </a>
             </List.Item>
             <List.Item>
-              The <a target="_blank" href="http://github.com/broadinstitute/seqr"><b>source code</b></a> is available on
+              The <a target="_blank" href="http://github.com/populationgenomics/seqr"><b>source code</b></a> is available on
               github. Please use the &nbsp;
               <a target="_blank" href="http://github.com/populationgenomics/seqr/issues"><b>github issues page</b></a> to
               submit bug reports or feature requests

--- a/ui/pages/Public/LandingPage.jsx
+++ b/ui/pages/Public/LandingPage.jsx
@@ -61,7 +61,7 @@ export default () =>
             <List.Item>
               The <a target="_blank" href="http://github.com/broadinstitute/seqr"><b>source code</b></a> is available on
               github. Please use the &nbsp;
-              <a target="_blank" href="http://github.com/broadinstitute/seqr/issues"><b>github issues page</b></a> to
+              <a target="_blank" href="http://github.com/populationgenomics/seqr/issues"><b>github issues page</b></a> to
               submit bug reports or feature requests
             </List.Item>
           </List>

--- a/ui/pages/Public/LandingPage.jsx
+++ b/ui/pages/Public/LandingPage.jsx
@@ -55,7 +55,7 @@ export default () =>
             <List.Item>
               To get updates about seqr, &nbsp;
               <a target="_blank" href="http://groups.google.com/a/broadinstitute.org/forum/#!forum/seqr-updates/join">
-                <b>join the Broad Institute's mailing list</b>
+                <b>join the Broad Institute&apos;s mailing list</b>
               </a>
             </List.Item>
             <List.Item>

--- a/ui/pages/Public/LandingPage.jsx
+++ b/ui/pages/Public/LandingPage.jsx
@@ -50,7 +50,7 @@ export default () =>
           <List bulleted>
             <List.Item>
               If you are interested in collaborating with our group, please &nbsp;
-              <a href="mailto:seqr@broadinstitute.org"><b>contact us</b></a>
+              <a href="mailto:seqr@populationgenomics.org.au"><b>contact us</b></a>
             </List.Item>
             <List.Item>
               To get updates about seqr, &nbsp;

--- a/ui/pages/Public/MatchmakerInfo.jsx
+++ b/ui/pages/Public/MatchmakerInfo.jsx
@@ -29,7 +29,7 @@ export default () =>
         </Grid.Row>
         <Grid.Row>
           <Grid.Column>
-            Please contact us at <a href="mailto:matchmaker@broadinstitute.org">matchmaker@broad</a>.
+            Please contact us at <a href="mailto:matchmaker@populationgenomics.org.au">matchmaker@broad</a>.
           </Grid.Column>
         </Grid.Row>
       </Grid>

--- a/ui/pages/Public/MatchmakerInfo.jsx
+++ b/ui/pages/Public/MatchmakerInfo.jsx
@@ -23,7 +23,7 @@ export default () =>
               at the <a target="_blank" href="https://cmg.broadinstitute.org/">Center for Mendelian Genomics</a> at the
               &nbsp; <a target="_blank" href="https://www.broadinstitute.org/">Broad Institute of MIT and Harvard</a>
               (Broad CMG). To use <i>matchbox</i>, you must be a collaborator and have your data deposited in the
-              &nbsp; <a target="_blank" href="https://seqr.broadinstitute.org"><i>seqr</i></a> platform
+              &nbsp; <a target="_blank" href="https://seqr.populationgenomics.org.au"><i>seqr</i></a> platform
             </p>
           </Grid.Column>
         </Grid.Row>

--- a/ui/pages/Search/fixtures.js
+++ b/ui/pages/Search/fixtures.js
@@ -218,7 +218,7 @@ export const STATE = {
   genesById: { [GENE_ID]: { geneId: GENE_ID, geneSymbol: 'OR2M3' } },
   user: {
     date_joined: '2015-02-19T20:22:50.633Z',
-    email: 'test@broadinstitute.org',
+    email: 'seqr+test@populationgenomics.org.au',
     first_name: '',
     id: 1,
     is_active: true,

--- a/ui/shared/components/page/BaseLayout.test.js
+++ b/ui/shared/components/page/BaseLayout.test.js
@@ -14,7 +14,7 @@ test('shallow-render without crashing', () => {
   const props = {
     user: {
       date_joined: '2015-02-19T20:22:50.633Z',
-      email: 'test@broadinstitute.org',
+      email: 'seqr+test@populationgenomics.org.au',
       first_name: '',
       id: 1,
       is_active: true,

--- a/ui/shared/components/page/Footer.jsx
+++ b/ui/shared/components/page/Footer.jsx
@@ -26,7 +26,7 @@ const Footer = React.memo(({ version }) =>
         <TableHeaderCell collapsing><Link to="/terms_of_service">Terms of Service</Link></TableHeaderCell>
         <TableHeaderCell>
           For bug reports or feature requests please submit  &nbsp;
-          <a href="https://github.com/broadinstitute/seqr/issues">Github Issues</a>
+          <a href="https://github.com/populationgenomics/seqr/issues">Github Issues</a>
         </TableHeaderCell>
         <TableHeaderCell collapsing textAlign="right">
           If you have questions or feedback, &nbsp;

--- a/ui/shared/components/page/Footer.jsx
+++ b/ui/shared/components/page/Footer.jsx
@@ -31,7 +31,7 @@ const Footer = React.memo(({ version }) =>
         <TableHeaderCell collapsing textAlign="right">
           If you have questions or feedback, &nbsp;
           <a
-            href="https://mail.google.com/mail/?view=cm&amp;fs=1&amp;tf=1&amp;to=seqr@broadinstitute.org"
+            href="https://mail.google.com/mail/?view=cm&amp;fs=1&amp;tf=1&amp;to=seqr@populationgenomics.org.au"
             target="_blank"
           >
             Contact Us

--- a/ui/shared/components/page/Header.test.js
+++ b/ui/shared/components/page/Header.test.js
@@ -13,7 +13,7 @@ test('shallow-render without crashing', () => {
   const props = {
     user: {
       date_joined: '2015-02-19T20:22:50.633Z',
-      email: 'test@broadinstitute.org',
+      email: 'seqr+test@populationgenomics.org.au',
       first_name: '',
       id: 1,
       is_active: true,

--- a/ui/shared/components/panel/fixtures.js
+++ b/ui/shared/components/panel/fixtures.js
@@ -2,7 +2,7 @@
 
 export const USER = {
   date_joined: '2015-02-19T20:22:50.633Z',
-  email: 'test@broadinstitute.org',
+  email: 'seqr+test@populationgenomics.org.au',
   first_name: '',
   id: 1,
   is_active: true,


### PR DESCRIPTION
- Updated instance links `seqr.broad` -> `seqr.popgen`
- Updated most repo links (except for those that link to specific issues)
- Email updates:
  - `seqr@broad` -> `seqr@popgen`
  - `matchmaker@broad` -> `matchmaker@popgen` (we probably need to create a group for this)
  - `test_user@broad` -> `seqr+test_user@popgen`
  - `test@broad` -> `seqr+test@popgen`
  - `UDNCC@hms.harvard.edu` -> `seqr+udncc@popgen`
  - `matchmaker@phenomecentral.org` -> `matchmaker+phenomecentral@popgen`
