### PR TITLE
Upload trivy results to GH security

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - dev
+      - add-trivy-to-security # remove on PR
 
 jobs:
   docker:
@@ -19,15 +20,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: gcloud setup
-        uses: google-github-actions/setup-gcloud@master
-        with:
-          project_id: seqr-308602
-          service_account_key: ${{ secrets.GCP_DEPLOY_KEY }}
+      # - name: gcloud setup
+      #   uses: google-github-actions/setup-gcloud@master
+      #   with:
+      #     project_id: seqr-308602
+      #     service_account_key: ${{ secrets.GCP_DEPLOY_KEY }}
 
-      - name: gcloud docker auth
-        run: |
-          gcloud auth configure-docker australia-southeast1-docker.pkg.dev
+      # - name: gcloud docker auth
+      #   run: |
+      #     gcloud auth configure-docker australia-southeast1-docker.pkg.dev
       
       - name: set deployment type
         run: |
@@ -57,14 +58,21 @@ jobs:
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: '${{ env.DOCKER_IMAGE }}:${{ github.sha }}'
-          format: 'table'
-          exit-code: '1'
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'
+          # upload trivvy results to GH security tab
+          format: 'template'
+          template: '@/contrib/sarif.tpl'
+          output: 'trivy-results.sarif'
+          
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: 'trivy-results.sarif'
 
-      - name: push image
-        run: docker push --all-tags $DOCKER_IMAGE
+      # - name: push image
+      #   run: docker push --all-tags $DOCKER_IMAGE
 
-      - name: restart seqr instances
-        run: gcloud compute instance-groups managed rolling-action replace seqr-$DEPLOYMENT_TYPE-group --region australia-southeast1 --max-unavailable 0 --max-surge 3
+      # - name: restart seqr instances
+      #   run: gcloud compute instance-groups managed rolling-action replace seqr-$DEPLOYMENT_TYPE-group --region australia-southeast1 --max-unavailable 0 --max-surge 3

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - dev
-      - add-trivy-to-security # remove on PR
 
 jobs:
   docker:
@@ -20,15 +19,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      # - name: gcloud setup
-      #   uses: google-github-actions/setup-gcloud@master
-      #   with:
-      #     project_id: seqr-308602
-      #     service_account_key: ${{ secrets.GCP_DEPLOY_KEY }}
+      - name: gcloud setup
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          project_id: seqr-308602
+          service_account_key: ${{ secrets.GCP_DEPLOY_KEY }}
 
-      # - name: gcloud docker auth
-      #   run: |
-      #     gcloud auth configure-docker australia-southeast1-docker.pkg.dev
+      - name: gcloud docker auth
+        run: |
+          gcloud auth configure-docker australia-southeast1-docker.pkg.dev
       
       - name: set deployment type
         run: |
@@ -54,25 +53,8 @@ jobs:
             -f deploy/docker/seqr/Dockerfile \
             .
 
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: '${{ env.DOCKER_IMAGE }}:${{ github.sha }}'
-          ignore-unfixed: true
-          vuln-type: 'os,library'
-          severity: 'CRITICAL,HIGH'
-          # upload trivvy results to GH security tab
-          format: 'template'
-          template: '@/contrib/sarif.tpl'
-          output: 'trivy-results.sarif'
-          
-      - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v1
-        with:
-          sarif_file: 'trivy-results.sarif'
+      - name: push image
+        run: docker push --all-tags $DOCKER_IMAGE
 
-      # - name: push image
-      #   run: docker push --all-tags $DOCKER_IMAGE
-
-      # - name: restart seqr instances
-      #   run: gcloud compute instance-groups managed rolling-action replace seqr-$DEPLOYMENT_TYPE-group --region australia-southeast1 --max-unavailable 0 --max-surge 3
+      - name: restart seqr instances
+        run: gcloud compute instance-groups managed rolling-action replace seqr-$DEPLOYMENT_TYPE-group --region australia-southeast1 --max-unavailable 0 --max-surge 3

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: '${{ env.DOCKER_IMAGE }}:prod'
+          image-ref: '${{ env.DOCKER_IMAGE }}:gcloud-prod'
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'
@@ -52,7 +52,7 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: '${{ env.DOCKER_IMAGE }}:dev'
+          image-ref: '${{ env.DOCKER_IMAGE }}:gcloud-dev'
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -31,6 +31,11 @@ jobs:
         run: |
           gcloud auth configure-docker australia-southeast1-docker.pkg.dev
 
+      - name: pull dockers
+        run: |
+          docker pull ${{ env.DOCKER_IMAGE }}:gcloud-prod
+          docker pull ${{ env.DOCKER_IMAGE }}:gcloud-dev
+
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -13,7 +13,7 @@ jobs:
     env:
       # BUILDKIT_PROGRESS: plain
       CLOUDSDK_CORE_DISABLE_PROMPTS: 1
-      DOCKER_IMAGE: australia-southeast1-docker.pkg.dev/seqr-308602/seqr-project/seqr
+      DOCKER_IMAGE: australia-southeast1-docker.pkg.dev/seqr-308602/seqr-project/seqr:gcloud-prod
 
     steps:
       # - uses: actions/checkout@v2
@@ -29,12 +29,12 @@ jobs:
 
       - name: pull dockers
         run: |
-          docker pull ${{ env.DOCKER_IMAGE }}:gcloud-prod
+          docker pull ${{ env.DOCKER_IMAGE }}
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: '${{ env.DOCKER_IMAGE }}:gcloud-prod'
+          image-ref: '${{ env.DOCKER_IMAGE }}'
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'
@@ -55,7 +55,7 @@ jobs:
     env:
       # BUILDKIT_PROGRESS: plain
       CLOUDSDK_CORE_DISABLE_PROMPTS: 1
-      DOCKER_IMAGE: australia-southeast1-docker.pkg.dev/seqr-308602/seqr-project/seqr
+      DOCKER_IMAGE: australia-southeast1-docker.pkg.dev/seqr-308602/seqr-project/seqr:gcloud-dev
 
     steps:
       # - uses: actions/checkout@v2
@@ -71,12 +71,12 @@ jobs:
 
       - name: pull dockers
         run: |
-          docker pull ${{ env.DOCKER_IMAGE }}:gcloud-dev
+          docker pull ${{ env.DOCKER_IMAGE }}
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: '${{ env.DOCKER_IMAGE }}:gcloud-dev'
+          image-ref: '${{ env.DOCKER_IMAGE }}'
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: '${{ env.DOCKER_IMAGE }}'
+          image-ref: ${{ env.DOCKER_IMAGE }}
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'
@@ -76,7 +76,7 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: '${{ env.DOCKER_IMAGE }}'
+          image-ref: ${{ env.DOCKER_IMAGE }}
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -5,10 +5,6 @@ on:
   schedule:
     - cron:  '0 22 * * 0' # each Monday at 9am AEST+10 / 10am AEDT+11
 
-  push:
-    branches:
-      - add-trivy-to-security
-
 jobs:
   trivy-prod:
     name: Trivy check

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,58 @@
+
+name: trivy
+on:
+  # runs on default branch
+  schedule:
+    - cron:  '0 22 * * 0' # each Monday at 9am AEST+10 / 10am AEDT+11
+
+  push:
+    branches:
+      - add-trivy-to-security
+
+jobs:
+  trivy:
+    name: Trivy check
+    runs-on: ubuntu-latest
+
+    env:
+      BUILDKIT_PROGRESS: plain
+      CLOUDSDK_CORE_DISABLE_PROMPTS: 1
+      DOCKER_IMAGE: australia-southeast1-docker.pkg.dev/seqr-308602/seqr-project/seqr
+
+    steps:
+      # - uses: actions/checkout@v2
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: '${{ env.DOCKER_IMAGE }}:prod'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
+          # upload trivvy results to GH security tab
+          format: 'template'
+          template: '@/contrib/sarif.tpl'
+          output: 'trivy-results-prod.sarif'
+          
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: 'trivy-results-prod.sarif'
+
+      # dev
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: '${{ env.DOCKER_IMAGE }}:dev'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
+          # upload trivvy results to GH security tab
+          format: 'template'
+          template: '@/contrib/sarif.tpl'
+          output: 'trivy-results-dev.sarif'
+          
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: 'trivy-results-dev.sarif'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -10,7 +10,7 @@ on:
       - add-trivy-to-security
 
 jobs:
-  trivy:
+  trivy-prod:
     name: Trivy check
     runs-on: ubuntu-latest
 
@@ -34,7 +34,6 @@ jobs:
       - name: pull dockers
         run: |
           docker pull ${{ env.DOCKER_IMAGE }}:gcloud-prod
-          docker pull ${{ env.DOCKER_IMAGE }}:gcloud-dev
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
@@ -53,7 +52,31 @@ jobs:
         with:
           sarif_file: 'trivy-results-prod.sarif'
 
-      # dev
+  trivy-dev:
+    name: Trivy DEV check
+    runs-on: ubuntu-latest
+
+    env:
+      # BUILDKIT_PROGRESS: plain
+      CLOUDSDK_CORE_DISABLE_PROMPTS: 1
+      DOCKER_IMAGE: australia-southeast1-docker.pkg.dev/seqr-308602/seqr-project/seqr
+
+    steps:
+      # - uses: actions/checkout@v2
+      - name: gcloud setup
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          project_id: seqr-308602
+          service_account_key: ${{ secrets.GCP_DEPLOY_KEY }}
+
+      - name: gcloud docker auth
+        run: |
+          gcloud auth configure-docker australia-southeast1-docker.pkg.dev
+
+      - name: pull dockers
+        run: |
+          docker pull ${{ env.DOCKER_IMAGE }}:gcloud-dev
+
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -15,12 +15,21 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      BUILDKIT_PROGRESS: plain
+      # BUILDKIT_PROGRESS: plain
       CLOUDSDK_CORE_DISABLE_PROMPTS: 1
       DOCKER_IMAGE: australia-southeast1-docker.pkg.dev/seqr-308602/seqr-project/seqr
 
     steps:
       # - uses: actions/checkout@v2
+      - name: gcloud setup
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          project_id: seqr-308602
+          service_account_key: ${{ secrets.GCP_DEPLOY_KEY }}
+
+      - name: gcloud docker auth
+        run: |
+          gcloud auth configure-docker australia-southeast1-docker.pkg.dev
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master


### PR DESCRIPTION
Move trivy as separate workflow that runs once a week, and uploads reports to security tab.

- Example of trivy workflow run: https://github.com/populationgenomics/seqr/runs/2723348852
- Code scanning results: https://github.com/populationgenomics/seqr/security/code-scanning?query=ref%3Arefs%2Fheads%2Fadd-trivy-to-security