### PR TITLE
Changed style-src-elem to style-src in CSP settings

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -67,7 +67,7 @@ CSRF_COOKIE_HTTPONLY = False
 SESSION_COOKIE_AGE = 86400 # seconds in 1 day
 X_FRAME_OPTIONS = 'SAMEORIGIN'
 
-CSP_INCLUDE_NONCE_IN = ['script-src', 'style-src']
+CSP_INCLUDE_NONCE_IN = ['script-src', 'style-src', 'style-src-elem']
 CSP_FONT_SRC = ('https://fonts.gstatic.com', 'data:')
 CSP_CONNECT_SRC = ("'self'", 'https://gtexportal.org', 'https://storage.googleapis.com') # used by IGV
 CSP_SCRIPT_SRC = ("'self'", "'unsafe-eval'")
@@ -75,6 +75,7 @@ CSP_SCRIPT_SRC = ("'self'", "'unsafe-eval'")
 IGV_CSS1_HASH = "'sha256-mMr3XKHeuAZnT2THF0+nzpjf/J0GLygO9xHcQduGITY='"
 IGV_CSS2_HASH = "'sha256-m7BbAVh3TyZH136+WARZw8eulS+0pHbppq98KGFYbhA='"
 CSP_STYLE_SRC = ('https://fonts.googleapis.com', "'self'", IGV_CSS1_HASH, IGV_CSS2_HASH)
+CSP_STYLE_SRC_ELEM = ('https://fonts.googleapis.com', "'self'", IGV_CSS1_HASH, IGV_CSS2_HASH)
 
 # django-debug-toolbar settings
 ENABLE_DJANGO_DEBUG_TOOLBAR = False

--- a/settings.py
+++ b/settings.py
@@ -67,14 +67,14 @@ CSRF_COOKIE_HTTPONLY = False
 SESSION_COOKIE_AGE = 86400 # seconds in 1 day
 X_FRAME_OPTIONS = 'SAMEORIGIN'
 
-CSP_INCLUDE_NONCE_IN = ['script-src', 'style-src-elem']
+CSP_INCLUDE_NONCE_IN = ['script-src', 'style-src']
 CSP_FONT_SRC = ('https://fonts.gstatic.com', 'data:')
 CSP_CONNECT_SRC = ("'self'", 'https://gtexportal.org', 'https://storage.googleapis.com') # used by IGV
 CSP_SCRIPT_SRC = ("'self'", "'unsafe-eval'")
 # IGV js injects CSS into the page head so there is no way to set nonce. Therefore, support hashed value of the CSS
 IGV_CSS1_HASH = "'sha256-mMr3XKHeuAZnT2THF0+nzpjf/J0GLygO9xHcQduGITY='"
 IGV_CSS2_HASH = "'sha256-m7BbAVh3TyZH136+WARZw8eulS+0pHbppq98KGFYbhA='"
-CSP_STYLE_SRC_ELEM = ('https://fonts.googleapis.com', "'self'", IGV_CSS1_HASH, IGV_CSS2_HASH)
+CSP_STYLE_SRC = ('https://fonts.googleapis.com', "'self'", IGV_CSS1_HASH, IGV_CSS2_HASH)
 
 # django-debug-toolbar settings
 ENABLE_DJANGO_DEBUG_TOOLBAR = False


### PR DESCRIPTION
Fixes #70. 

Firefox does not support the CSP directive 'style-src-elem' (confirmed here https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src-elem) and as such seqr does not load in firefox. 

We can work around this by changing 'style-src-elem' to the higher level 'style-src' and changing the corresponding CSP_STYLE_SRC_ELEM to CSP_STYLE_SRC. 

Unclear to me if this is a valid fix or may have any side-effects. @Hanars would love your input on this or other possible solutions. 