### PR TITLE
Modify `iter_file` to yield every line

### DIFF
--- a/seqr/utils/file_utils.py
+++ b/seqr/utils/file_utils.py
@@ -79,7 +79,10 @@ def file_iter(file_path, byte_range=None, raw_content=False, user=None):
                 chunk_end = end
             data = blob.download_as_bytes(start=current, end=chunk_end, checksum=None)
             current += len(data)
-            yield data if raw_content else data.decode("utf-8")
+            if not raw_content:
+                data = data.decode("utf-8")
+            for line in data.split('\n'):
+                yield line
             # We're done if we couldn't read the full range or we've reached the end.
             if current <= chunk_end or (end and current > end):
                 break


### PR DESCRIPTION
The function that parses a ID mapping file expects a file stream or a lines container: https://github.com/populationgenomics/seqr/blob/9bb5ed30f007cc7f339eb60bd0645a411d957f89/seqr/views/utils/file_utils.py#L35-L37

For context: https://centrepopgen.slack.com/archives/G01LY7N2RV1/p1629951649017100
