### PR TITLE
Add login link to welcome_email if google auth enabled

### DIFF
--- a/seqr/utils/communication_utils.py
+++ b/seqr/utils/communication_utils.py
@@ -4,7 +4,7 @@ from settings import SLACK_TOKEN, BASE_URL
 from django.core.mail import EmailMultiAlternatives
 from django.utils.html import strip_tags
 
-from seqr.views.utils.terra_api_utils import anvil_enabled
+from seqr.views.utils.terra_api_utils import anvil_enabled, google_auth_enabled
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +31,9 @@ def _post_to_slack(channel, message):
 
 
 def send_welcome_email(user, referrer):
-    if anvil_enabled():
+    if google_auth_enabled():
+        setup_message = 'You can now login to seqr using your connected google account:\n    {}login/google-oauth2'.format(BASE_URL)
+    elif anvil_enabled():
         setup_message = 'Please make sure this account is registered in AnVIL by signing in to {} and registering.'.format(
             ANVIL_UI_URL
         )

--- a/seqr/utils/communication_utils.py
+++ b/seqr/utils/communication_utils.py
@@ -32,7 +32,7 @@ def _post_to_slack(channel, message):
 
 def send_welcome_email(user, referrer):
     if google_auth_enabled():
-        setup_message = 'You can now login to seqr using your connected google account:\n    {}login/google-oauth2'.format(BASE_URL)
+        setup_message = 'You can now login to seqr using your google account:\n    {}login/google-oauth2'.format(BASE_URL)
     elif anvil_enabled():
         setup_message = 'Please make sure this account is registered in AnVIL by signing in to {} and registering.'.format(
             ANVIL_UI_URL

--- a/seqr/utils/communication_utils.py
+++ b/seqr/utils/communication_utils.py
@@ -32,7 +32,7 @@ def _post_to_slack(channel, message):
 
 def send_welcome_email(user, referrer):
     if google_auth_enabled():
-        setup_message = 'You can now login to seqr using your google account:\n    {}login/google-oauth2'.format(BASE_URL)
+        setup_message = 'You can now log into seqr using your Google account:\n    {}login/google-oauth2'.format(BASE_URL)
     elif anvil_enabled():
         setup_message = 'Please make sure this account is registered in AnVIL by signing in to {} and registering.'.format(
             ANVIL_UI_URL


### PR DESCRIPTION
Example email:

```
    Hi there MICHAEL (TEST) Franklin--

    email@address has added you as a collaborator in seqr.

    You can now login to seqr using your connected google account:
    $BASE_URL/login/google-oauth2

    Thanks!
```