### PR TITLE
Pin setup-gcloud version

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: gcloud setup
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: seqr-308602
           service_account_key: ${{ secrets.GCP_DEPLOY_KEY }}


### PR DESCRIPTION
Based on this recommendation:

Warning: google-github-actions/setup-gcloud is pinned at "master". We strongly advise against pinning to "@master" as it may be unstable. Please update your GitHub Action YAML from:

    uses: 'google-github-actions/setup-gcloud@master'

to:

    uses: 'google-github-actions/setup-gcloud@v0'

Alternatively, you can pin to any git tag or git SHA in the repository.