### PR TITLE
Allow exception in custom bearer middleware

### DIFF
--- a/seqr/utils/auth_middleware.py
+++ b/seqr/utils/auth_middleware.py
@@ -25,11 +25,6 @@ class CheckServiceAccountAccessMiddleware(MiddlewareMixin):
             # Some URLs do not resolve, like /login/google-oauth2
             # We're not trying to block anything, so let's just pass along
             pass
-        except Exception as e:
-            # There should be no errors within this middleware,
-            # logging and continuing, as it will block programmatic access
-            logger.error(f'There was an exception during {self.__class__.__name__}: {e}')
-
 
 
 class DisableCSRFServiceAccountAccessMiddleware(MiddlewareMixin):

--- a/seqr/utils/auth_middleware.py
+++ b/seqr/utils/auth_middleware.py
@@ -8,7 +8,7 @@ from django.utils.deprecation import MiddlewareMixin
 from google.oauth2 import id_token
 from google.auth.transport import requests
 
-from seqr.views.utils.permissions_utils import ServiceAccountAccess, logger
+from seqr.views.utils.permissions_utils import ServiceAccountAccess
 
 from settings import SOCIAL_AUTH_GOOGLE_OAUTH2_KEY
 

--- a/seqr/utils/auth_middleware.py
+++ b/seqr/utils/auth_middleware.py
@@ -17,6 +17,8 @@ class CheckServiceAccountAccessMiddleware(MiddlewareMixin):
 
     def process_request(self, request):
         try:
+            # do this before any other methods can throw an error
+            request.service_account_access = False
             func, _, _ = resolve(request.path)
             request.service_account_access = isinstance(func, ServiceAccountAccess)
         except Resolver404:

--- a/seqr/utils/auth_middleware.py
+++ b/seqr/utils/auth_middleware.py
@@ -8,7 +8,7 @@ from django.utils.deprecation import MiddlewareMixin
 from google.oauth2 import id_token
 from google.auth.transport import requests
 
-from seqr.views.utils.permissions_utils import ServiceAccountAccess
+from seqr.views.utils.permissions_utils import ServiceAccountAccess, logger
 
 from settings import SOCIAL_AUTH_GOOGLE_OAUTH2_KEY
 
@@ -23,10 +23,11 @@ class CheckServiceAccountAccessMiddleware(MiddlewareMixin):
             # Some URLs do not resolve, like /login/google-oauth2
             # We're not trying to block anything, so let's just pass along
             pass
-        except:
+        except Exception as e:
             # There should be no errors within this middleware,
-            # any uncaught errors will block access to the route anyway
-            pass
+            # logging and continuing, as it will block programmatic access
+            logger.error(f'There was an exception during {self.__class__.__name__}: {e}')
+
 
 
 class DisableCSRFServiceAccountAccessMiddleware(MiddlewareMixin):


### PR DESCRIPTION
Sometimes routes don't resolve because other middleware takes care of them, we should not be picky about this, we should simply just pass along if it's a route we don't recognise.