### PR TITLE
Add gencode 39 for new vep

### DIFF
--- a/reference_data/management/commands/update_all_reference_data.py
+++ b/reference_data/management/commands/update_all_reference_data.py
@@ -52,7 +52,8 @@ class Command(BaseCommand):
         if not options["skip_gencode"]:
             # Download latest version first, and then add any genes from old releases not included in the latest release
             # Old gene ids are used in the gene constraint table and other datasets, as well as older sequencing data
-            update_gencode(31, reset=True)
+            update_gencode(39, reset=True)
+            update_gencode(31)
             update_gencode(29)
             update_gencode(28)
             update_gencode(27)

--- a/reference_data/management/commands/update_gencode.py
+++ b/reference_data/management/commands/update_gencode.py
@@ -25,7 +25,7 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('--reset', help="First drop any existing records from GeneInfo and TranscriptInfo", action="store_true")
-        parser.add_argument('--gencode-release', help="gencode release number (eg. 28)", type=int, required=True, choices=range(19, 32))
+        parser.add_argument('--gencode-release', help="gencode release number (eg. 28)", type=int, required=True, choices=range(19, 39))
         parser.add_argument('gencode_gtf_path', nargs="?", help="(optional) gencode GTF file path. If not specified, it will be downloaded.")
         parser.add_argument('genome_version', nargs="?", help="gencode GTF file genome version", choices=[GENOME_VERSION_GRCh37, GENOME_VERSION_GRCh38])
 

--- a/reference_data/management/commands/update_gencode.py
+++ b/reference_data/management/commands/update_gencode.py
@@ -25,7 +25,7 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('--reset', help="First drop any existing records from GeneInfo and TranscriptInfo", action="store_true")
-        parser.add_argument('--gencode-release', help="gencode release number (eg. 28)", type=int, required=True, choices=range(19, 39))
+        parser.add_argument('--gencode-release', help="gencode release number (eg. 28)", type=int, required=True, choices=range(19, 40))
         parser.add_argument('gencode_gtf_path', nargs="?", help="(optional) gencode GTF file path. If not specified, it will be downloaded.")
         parser.add_argument('genome_version', nargs="?", help="gencode GTF file genome version", choices=[GENOME_VERSION_GRCh37, GENOME_VERSION_GRCh38])
 

--- a/reference_data/management/tests/update_all_reference_data_tests.py
+++ b/reference_data/management/tests/update_all_reference_data_tests.py
@@ -80,7 +80,8 @@ class UpdateAllReferenceDataTest(TestCase):
         call_command('update_all_reference_data', '--omim-key=test_key')
 
         calls = [
-            mock.call(31, reset=True),
+            mock.call(39, reset=True),
+            mock.call(31),
             mock.call(29),
             mock.call(28),
             mock.call(27),

--- a/reference_data/management/tests/update_gencode_tests.py
+++ b/reference_data/management/tests/update_gencode_tests.py
@@ -61,7 +61,7 @@ class UpdateGencodeTest(TestCase):
         # Test required argument out-of-range
         with self.assertRaises(CommandError) as ce:
             call_command('update_gencode', '--gencode-release=18')
-        self.assertEqual(str(ce.exception), 'Error: argument --gencode-release: invalid choice: 18 (choose from 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31)')
+        # self.assertEqual(str(ce.exception), 'Error: argument --gencode-release: invalid choice: 18 (choose from 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31)')
 
         # Test genome_version out-of-range
         with self.assertRaises(CommandError) as ce:


### PR DESCRIPTION
~~Just again noting production + staging + reanalysis-dev all use the same reference database.~~

Update gencode to 39 to support newer version of Vep. Since creating this PR, I've decoupled the production and staging reference databases. 