### PR TITLE
Use more gunicorn workers

### DIFF
--- a/deploy/docker/seqr/config/gunicorn_config.py
+++ b/deploy/docker/seqr/config/gunicorn_config.py
@@ -1,6 +1,6 @@
 command = 'gunicorn'
 bind = '0.0.0.0:8000'
-workers = 1
+workers = 9  # (2 * 4 cores) + 1, as suggested in https://docs.gunicorn.org/en/stable/design.html#how-many-workers
 loglevel = 'info'
 timeout = 3600   # seconds (default is 30)
 errorlog = '-'  # logs to stderr


### PR DESCRIPTION
Which should hopefully help with load spikes not returning 502s on underutilized VMs.

Context: https://centrepopgen.slack.com/archives/C01R7CKJGHM/p1681443985537919