### PR TITLE
Sync analysis notes

### DIFF
--- a/seqr/views/apis/family_api.py
+++ b/seqr/views/apis/family_api.py
@@ -123,7 +123,7 @@ def edit_families_handler_base(request, project_guid):
             missing_guids = set(family_guids) - set(family_models.keys())
             return create_json_response({'error': 'Invalid family guids: {}'.format(', '.join(missing_guids))}, status=400)
 
-        family_analysis_notes = {family_guid : {note_guid : note for note_guid, note in family_note.items() if note.get('NoteType') == 'A'} for family_guid, family_note in family_notes.items() }
+        family_analysis_notes = {note.family.guid : {note_guid : note.note for note_guid, note in family_note.items() if note.get('NoteType') == 'A'} for family_note in family_notes['familyNotesByGuid']}
         
         updated_family_analysis_notes = {}
         for family_guid in family_guids:

--- a/seqr/views/apis/family_api.py
+++ b/seqr/views/apis/family_api.py
@@ -2,13 +2,16 @@
 APIs used to retrieve and modify Individual fields
 """
 import json
+import requests
 from collections import defaultdict
 from django.contrib.auth.models import User
 from django.db.models import Count
 from django.db.models.fields.files import ImageFieldFile
+from django.urls.base import reverse
 
 from matchmaker.models import MatchmakerSubmission
 from seqr.utils.gene_utils import get_genes_for_variant_display
+from seqr.views.apis.project_api import project_family_notes
 from seqr.views.utils.file_utils import save_uploaded_file, load_uploaded_file
 from seqr.views.utils.individual_utils import delete_individuals
 from seqr.views.utils.json_to_orm_utils import update_family_from_json, update_model_from_json, \
@@ -111,12 +114,36 @@ def edit_families_handler_base(request, project_guid):
             {}, status=400, reason="'families' not specified")
 
     family_guids = [f['familyGuid'] for f in modified_families if f.get('familyGuid')]
+    family_notes = project_family_notes(request, project_guid)
+
     family_models = {}
     if family_guids:
         family_models.update({f.guid: f for f in Family.objects.filter(project=project, guid__in=family_guids)})
         if len(family_models) != len(family_guids):
             missing_guids = set(family_guids) - set(family_models.keys())
             return create_json_response({'error': 'Invalid family guids: {}'.format(', '.join(missing_guids))}, status=400)
+
+        family_analysis_notes = {family_guid : {note_guid : note for note_guid, note in family_note.items() if note.get('NoteType') == 'A'} for family_guid, family_note in family_notes.items() }
+        
+        updated_family_analysis_notes = {}
+        for family_guid in family_guids:
+            if not family_analysis_notes.get(family_guid):
+                new_note = '# Test\nAnalysis note\n - *note* 1\n - **note** 2'
+                create_note_url = reverse(create_family_note, args=[family_guid])
+                requests.post(create_note_url, content_type='application/json', data=json.dumps({'note': new_note, 'noteType': 'A'}))
+                continue
+
+            updated_analysis_notes = {}
+            analysis_note = family_analysis_notes[family_guid]
+            for note_guid, note in analysis_note.items():
+                updated_note = note + '\n# Test\nAnalysis note\n - *note* 1\n - **note** 2'
+                updated_analysis_notes[note_guid] = updated_note
+
+                update_note_url = reverse(update_family_note, args=[family_guid, note_guid])
+                requests.post(update_note_url, content_type='application/json',  data=json.dumps({'note': updated_note}))
+
+            updated_family_analysis_notes[family_guid] = updated_analysis_notes
+            
 
         updated_family_ids = {
             fields[FAMILY_ID_FIELD]: family_models[fields['familyGuid']].family_id for fields in modified_families


### PR DESCRIPTION
Attempting to do some work on the Analysis Notes field... I'm planning to try and spin up a local seqr instance to test some of this, just publishing this draft PR to see if I should continue with this approach.

The logic behind this:
1. The Metamist - Seqr [sync process](https://github.com/populationgenomics/sample-metadata/blob/9601e0205e9eb4a9024fe45420529edbc63756d8/scripts/sync_seqr.py#L263) syncs families across a project with the service-account endpoint [sa_sync_families](https://github.com/populationgenomics/seqr/blob/3b0b4feb4e3ac51731c086a299ab7274ef4c38bd/seqr/views/apis/family_api.py#L472), which syncs the family description, phenotypes, etc. by calling the [edit_families_handler_base](https://github.com/populationgenomics/seqr/blob/3b0b4feb4e3ac51731c086a299ab7274ef4c38bd/seqr/views/apis/family_api.py#L96) function.
2. This function utilises the project GUID and family GUIDs to update the various family fields. My idea is to sneak the analysis note updates into this call, since doing so will need those GUIDs.
3. So, we import [project_family_notes](https://github.com/populationgenomics/seqr/blob/3b0b4feb4e3ac51731c086a299ab7274ef4c38bd/seqr/views/apis/project_api.py#L278) from the project_api, which gets all the family notes from the project. We filter this down to just analysis notes, so we can know which families already have Analysis Notes and which families need an analysis note to be created.
4. Iterating through the families, if the family has no analysis note we create one, and if the family currently has an analysis note we append the new note to the end of it after a line break. This will have to be changed so that notes aren't just endlessly appended to once they exist, but we'll get to that.
5. Once a note has been created or updated, we post a request to the url using the family/note GUID with the django's reverse function, the create/update_family_note url, and requests post function.

I have a few questions about my approach
 - Is it a good idea to hamfist this into the sync_families step of the sync_seqr process, or should a new service-account endpoint be created? 
- Is it bad practice to import a function from one api into another? Regarding step 3. where project_family_notes is imported from project_api.
 - Will the service account even have the permissions to make other API calls like project_family_notes and create/update_family_note?
 - Is this a reasonable use of reverse() and requests.post? The only examples I could find where the family notes are updated were in the [family_api_tests](https://github.com/populationgenomics/seqr/blob/3b0b4feb4e3ac51731c086a299ab7274ef4c38bd/seqr/views/apis/family_api_tests.py#L432) so I was trying to model that behaviour.
