### PR TITLE
Fix dataset type lookup in search utils for non-mito variants

### DIFF
--- a/seqr/utils/search/utils.py
+++ b/seqr/utils/search/utils.py
@@ -40,7 +40,7 @@ DATASET_TYPES_LOOKUP = {
 }
 DATASET_TYPES_LOOKUP[ALL_DATA_TYPES] = [dt for dts in DATASET_TYPES_LOOKUP.values() for dt in dts]
 DATASET_TYPE_SNP_INDEL_ONLY = f'{Sample.DATASET_TYPE_VARIANT_CALLS}_only'
-DATASET_TYPES_LOOKUP[DATASET_TYPE_SNP_INDEL_ONLY] = [Sample.DATASET_TYPE_VARIANT_CALLS]
+DATASET_TYPES_LOOKUP[DATASET_TYPE_SNP_INDEL_ONLY] = Sample.DATASET_TYPE_VARIANT_CALLS
 
 
 def _raise_search_error(error):
@@ -346,7 +346,7 @@ def _variant_ids_dataset_type(variant_ids):
     if len(has_mito) == len(variant_ids):
         return Sample.DATASET_TYPE_MITO_CALLS
     elif not has_mito:
-        return DATASET_TYPES_LOOKUP[DATASET_TYPE_SNP_INDEL_ONLY]
+        return DATASET_TYPE_SNP_INDEL_ONLY
     return Sample.DATASET_TYPE_VARIANT_CALLS
 
 

--- a/seqr/utils/search/utils.py
+++ b/seqr/utils/search/utils.py
@@ -346,7 +346,7 @@ def _variant_ids_dataset_type(variant_ids):
     if len(has_mito) == len(variant_ids):
         return Sample.DATASET_TYPE_MITO_CALLS
     elif not has_mito:
-        return DATASET_TYPE_SNP_INDEL_ONLY
+        return DATASET_TYPES_LOOKUP[DATASET_TYPE_SNP_INDEL_ONLY]
     return Sample.DATASET_TYPE_VARIANT_CALLS
 
 


### PR DESCRIPTION
Was facing a peculiar error message when trying to import AIP results. 

![image](https://github.com/populationgenomics/seqr/assets/34049565/b363e04b-c472-4ccf-b399-afd3e31a671f)

Tracked this down to a bug where if there are no Mitochondrial variants in the list, it would set the dataset type as the string "SNV_INDEL_only", rather than the "SNV_INDEL" string that this should map to. Otherwise it tries to filter the samples on `dataset_type=="SNV_INDEL_only"` which returns nothing because no samples have this dataset type.



I think this was not caught by Broad because [in their test, they mock the call to](https://github.com/broadinstitute/seqr/blob/master/seqr/views/apis/summary_data_api_tests.py#L487) `get_variants_for_variant_ids` which calls the function being changed here, `_variant_ids_dataset_type`
