### PR TITLE
Update deploy actions versions, ignore apply schema cloudrun jobs for…

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -18,13 +18,17 @@ jobs:
       DOCKER_IMAGE: australia-southeast1-docker.pkg.dev/seqr-308602/seqr-project/seqr
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+
+      - id: "google-cloud-auth"
+        name: "Authenticate to Google Cloud"
+        uses: "google-github-actions/auth@v2"
+        with:
+          workload_identity_provider: ""
+          service_account: ""
 
       - name: gcloud setup
-        uses: google-github-actions/setup-gcloud@v0
-        with:
-          project_id: seqr-308602
-          service_account_key: ${{ secrets.GCP_DEPLOY_KEY }}
+        uses: google-github-actions/setup-gcloud@v2
 
       - name: gcloud docker auth
         run: |
@@ -40,7 +44,7 @@ jobs:
             echo DEPLOY_TARGET=reanalysis-dev >> $GITHUB_ENV
           fi
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 16
       - name: build UI
@@ -85,6 +89,7 @@ jobs:
             --max-surge 3
 
       - name: apply schema
+        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging'
         run: |
           gcloud beta run jobs execute --wait \
             --region australia-southeast1 \

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -20,16 +20,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: gcloud auth
-        uses: google-github-actions/auth@v2
+      - name: gcloud setup
+        uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: seqr-308602
-          credentials_json: ${{ secrets.GCP_DEPLOY_KEY }}
-      
-      - name: gcloud setup
-        uses: google-github-actions/setup-gcloud@v2
-        with: 
-          project_id: seqr-308602
+          service_account_key: ${{ secrets.GCP_DEPLOY_KEY }}
 
       - name: gcloud docker auth
         run: |

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -20,15 +20,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - id: "google-cloud-auth"
-        name: "Authenticate to Google Cloud"
-        uses: "google-github-actions/auth@v2"
+      - name: gcloud auth
+        uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: ""
-          service_account: ""
-
+          project_id: seqr-308602
+          credentials_json: ${{ secrets.GCP_DEPLOY_KEY }}
+      
       - name: gcloud setup
         uses: google-github-actions/setup-gcloud@v2
+        with: 
+          project_id: seqr-308602
 
       - name: gcloud docker auth
         run: |


### PR DESCRIPTION
… feature branches

Updates the deploy actions versions for Gcloud auth with placeholder for GCP federated identity (@illusional can you generate this please). Also updates the setup-node action version.

Also disables the final step (apply schema) for branches that aren't `main` or `staging`, since this step fails anyway for branches outside of those two. The commands run by this step are `manage.py migrate` and `manage.py migrate --database=reference_data`, and cloudrun jobs to invoke these commands only exist for `staging` and `main`.