### PR TITLE
Ignore apply schema cloudrun jobs for feature branches

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -18,7 +18,7 @@ jobs:
       DOCKER_IMAGE: australia-southeast1-docker.pkg.dev/seqr-308602/seqr-project/seqr
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: gcloud setup
         uses: google-github-actions/setup-gcloud@v0
@@ -40,7 +40,7 @@ jobs:
             echo DEPLOY_TARGET=reanalysis-dev >> $GITHUB_ENV
           fi
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 16
       - name: build UI
@@ -85,6 +85,7 @@ jobs:
             --max-surge 3
 
       - name: apply schema
+        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging'
         run: |
           gcloud beta run jobs execute --wait \
             --region australia-southeast1 \


### PR DESCRIPTION
* Update deploy actions versions, ignore apply schema cloudrun jobs for feature branches

To stop the final step of the github deploy action reporting failure when outside of the `staging` or `main` branches