### PR TITLE
Environment lock

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,6 +6,7 @@ on:
       - main
       - staging
       - reanalysis-dev
+      - environment-lock
 
 jobs:
   docker:
@@ -20,11 +21,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: gcloud setup
-        uses: google-github-actions/setup-gcloud@v0
+      - id: "google-cloud-auth"
+        name: "Authenticate to Google Cloud"
+        uses: "google-github-actions/auth@v2"
         with:
-          project_id: seqr-308602
-          service_account_key: ${{ secrets.GCP_DEPLOY_KEY }}
+          workload_identity_provider: "projects/1021400127367/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
+          service_account: "deploy@seqr-308602.iam.gserviceaccount.com"
 
       - name: gcloud docker auth
         run: |
@@ -38,6 +40,8 @@ jobs:
             echo DEPLOY_TARGET=staging >> $GITHUB_ENV
           elif [[ $GITHUB_REF == 'refs/heads/reanalysis-dev' ]]; then
             echo DEPLOY_TARGET=reanalysis-dev >> $GITHUB_ENV
+          elif [[ $GITHUB_REF == 'refs/heads/environment-lock' ]]; then
+            echo DEPLOY_TARGET=environment-lock >> $GITHUB_ENV
           fi
 
       - uses: actions/setup-node@v4

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   docker:
-    # environment: production
+    environment: production
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -46,7 +46,7 @@ jobs:
           elif [[ $GITHUB_REF == 'refs/heads/reanalysis-dev' ]]; then
             echo DEPLOY_TARGET=reanalysis-dev >> $GITHUB_ENV
           elif [[ $GITHUB_REF == 'refs/heads/environment-lock' ]]; then
-            echo DEPLOY_TARGET=environment-lock >> $GITHUB_ENV
+            echo DEPLOY_TARGET=staging >> $GITHUB_ENV
           fi
 
       - uses: actions/setup-node@v4

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,6 +8,10 @@ on:
       - reanalysis-dev
       - environment-lock
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,7 +6,6 @@ on:
       - main
       - staging
       - reanalysis-dev
-      - environment-lock
 
 permissions:
   id-token: write
@@ -45,8 +44,6 @@ jobs:
             echo DEPLOY_TARGET=staging >> $GITHUB_ENV
           elif [[ $GITHUB_REF == 'refs/heads/reanalysis-dev' ]]; then
             echo DEPLOY_TARGET=reanalysis-dev >> $GITHUB_ENV
-          elif [[ $GITHUB_REF == 'refs/heads/environment-lock' ]]; then
-            echo DEPLOY_TARGET=staging >> $GITHUB_ENV
           fi
 
       - uses: actions/setup-node@v4

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   docker:
-    environment: production
+    # environment: production
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   docker:
+    environment: production
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -13,7 +13,6 @@ jobs:
   trivy-prod:
     name: Trivy check
     runs-on: ubuntu-latest
-    environment: production
     env:
       # BUILDKIT_PROGRESS: plain
       CLOUDSDK_CORE_DISABLE_PROMPTS: 1
@@ -56,7 +55,6 @@ jobs:
   trivy-dev:
     name: Trivy DEV check
     runs-on: ubuntu-latest
-    environment: production
     env:
       # BUILDKIT_PROGRESS: plain
       CLOUDSDK_CORE_DISABLE_PROMPTS: 1

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -17,11 +17,12 @@ jobs:
 
     steps:
       # - uses: actions/checkout@v2
-      - name: gcloud setup
-        uses: google-github-actions/setup-gcloud@master
+      - id: "google-cloud-auth"
+        name: "Authenticate to Google Cloud"
+        uses: "google-github-actions/auth@v2"
         with:
-          project_id: seqr-308602
-          service_account_key: ${{ secrets.GCP_DEPLOY_KEY }}
+          workload_identity_provider: "projects/1021400127367/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
+          service_account: "trivy-scanner@seqr-308602.iam.gserviceaccount.com"
 
       - name: gcloud docker auth
         run: |

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -13,7 +13,7 @@ jobs:
   trivy-prod:
     name: Trivy check
     runs-on: ubuntu-latest
-
+    environment: production
     env:
       # BUILDKIT_PROGRESS: plain
       CLOUDSDK_CORE_DISABLE_PROMPTS: 1
@@ -56,7 +56,7 @@ jobs:
   trivy-dev:
     name: Trivy DEV check
     runs-on: ubuntu-latest
-
+    environment: production
     env:
       # BUILDKIT_PROGRESS: plain
       CLOUDSDK_CORE_DISABLE_PROMPTS: 1
@@ -64,11 +64,12 @@ jobs:
 
     steps:
       # - uses: actions/checkout@v2
-      - name: gcloud setup
-        uses: google-github-actions/setup-gcloud@master
+      - id: "google-cloud-auth"
+        name: "Authenticate to Google Cloud"
+        uses: "google-github-actions/auth@v2"
         with:
-          project_id: seqr-308602
-          service_account_key: ${{ secrets.GCP_DEPLOY_KEY }}
+          workload_identity_provider: "projects/1021400127367/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
+          service_account: "trivy-scanner@seqr-308602.iam.gserviceaccount.com"
 
       - name: gcloud docker auth
         run: |

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron:  '0 22 * * 0' # each Monday at 9am AEST+10 / 10am AEDT+11
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   trivy-prod:
     name: Trivy check

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "google-github-actions/auth@v2"
         with:
           workload_identity_provider: "projects/1021400127367/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
-          service_account: "trivy-scanner@seqr-308602.iam.gserviceaccount.com"
+          service_account: "github-trivy-workflow@seqr-308602.iam.gserviceaccount.com"
 
       - name: gcloud docker auth
         run: |
@@ -69,7 +69,7 @@ jobs:
         uses: "google-github-actions/auth@v2"
         with:
           workload_identity_provider: "projects/1021400127367/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
-          service_account: "trivy-scanner@seqr-308602.iam.gserviceaccount.com"
+          service_account: "github-trivy-workflow@seqr-308602.iam.gserviceaccount.com"
 
       - name: gcloud docker auth
         run: |


### PR DESCRIPTION
## Description
In a bid to introduce better security permissions, we have replaced the use of SA keys to workload identity providers. This change will also implement the use of environments to ensure deployments are going through the right channels.

## Changes
- [x]  Updated the workflow to use WIP over SA keys
- [x]  Added `environment` attribute