### PR TITLE
Add project argument to validate_fam_file_records

### DIFF
--- a/seqr/views/apis/individual_api.py
+++ b/seqr/views/apis/individual_api.py
@@ -1040,7 +1040,7 @@ def sa_sync_individuals(request, project_guid):
         return create_json_response({'errors': ['missing individuals in body']}, status=400)
 
 
-    warnings = validate_fam_file_records(json_records)
+    warnings = validate_fam_file_records(project_guid, json_records)
     _ = add_or_update_individuals_and_families(
         project=project,
         individual_records=json_records,


### PR DESCRIPTION
Add in the required project argument to the `validate_fam_file_records` call to prevent the error seen when attempting to sync "individuals" (a pedigree).

See [VM log entry](https://console.cloud.google.com/logs/query;cursorTimestamp=2024-05-30T03:46:27.640016709Z;duration=PT1H;query=resource.type%3D%22gce_instance%22%0Aresource.labels.instance_id%3D%228017852583431848651%22%0Atimestamp%3D%222024-05-30T03:46:27.639029676Z%22%0AinsertId%3D%221p1yldgfew4npl%22?project=seqr-308602)
```
"validate_fam_file_records() missing 1 required positional argument: 'records'", 
"user": "sample-metadata-api@sample-metadata.iam.gserviceaccount.com", 
"traceback": "Traceback (most recent call last):
     File "/usr/local/lib/python3.9/site-packages/django/core/handlers/base.py", line 181, in _get_response    
response = wrapped_callback(request, *callback_args, **callback_kwargs)
    File "/app/seqr/seqr/views/utils/permissions_utils.py", line 95, in __call__    
return self.func(*args, **kwargs)
    File "/app/seqr/seqr/views/utils/permissions_utils.py", line 111, in _check_user_func
return _wrapped_func(request, *args, **kwargs)
   File \"/app/seqr/seqr/views/apis/individual_api.py\", line 1043, in sa_sync_individuals
warnings = validate_fam_file_records(json_records)
TypeError: validate_fam_file_records() missing 1 required positional argument: 'records'
```

--- 

To replicate:
- Attempt to POST to `http://seqr.populationgenomics.org.au/api/project/sa/<PROJECT_GUID>/individuals/sync`
(most easily done via [Metamist project page](https://sample-metadata.populationgenomics.org.au/project), click sync and then uncheck all boxes except "sync pedigree")
- requestBody is well formed, but the API logic triggers the above error
```
requestBody": {
    "individuals": [
        {"familyId": "UDN0007", "individualId": "UDN0007PR", "paternalId": "UDN0007P", "maternalId": "UDN0007M", "notes": "", "sex": "M", "affected": "A"},
        ...
    ]
}
```

---

The change to have project in the required args was added upstream 2 months ago. https://github.com/populationgenomics/seqr/blob/main/seqr/views/utils/pedigree_info_utils.py#L241

During the merge I must have missed this change. It's the only instance I can see where this happens. I'll make sure this change is merged into staging/dev too.