### PR TITLE
Change project guid arg to project in sa sync function

### DIFF
--- a/seqr/views/apis/individual_api.py
+++ b/seqr/views/apis/individual_api.py
@@ -1040,7 +1040,7 @@ def sa_sync_individuals(request, project_guid):
         return create_json_response({'errors': ['missing individuals in body']}, status=400)
 
 
-    warnings = validate_fam_file_records(project_guid, json_records)
+    warnings = validate_fam_file_records(project, json_records)
     _ = add_or_update_individuals_and_families(
         project=project,
         individual_records=json_records,


### PR DESCRIPTION
Hotfix for bug introduced in #222, I put `project_guid` as the project arg in the `validate_fam_file_records` function, but really it needs the Numerical project ID. 

With project_guid in this place, there is a different error:
```
ValueError: Field 'id' expected a number but got <PROJECT_GUID_STRING>
```

Luckily the numerical project ID is fetched a few lines above:
`project = get_project_and_check_pm_permissions(project_guid, request.user)`



