### PR TITLE
Update CodeQL action version

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -50,7 +50,7 @@ jobs:
           output: 'trivy-results-prod.sarif'
           
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: 'trivy-results-prod.sarif'
 


### PR DESCRIPTION
v1 is deprecated and is causing the trivy workflow to fail. This should hopefully patch that :)