### PR TITLE
populationgenomics url in FeatureUpdates ui

### DIFF
--- a/ui/pages/Public/components/FeatureUpdates.jsx
+++ b/ui/pages/Public/components/FeatureUpdates.jsx
@@ -17,7 +17,7 @@ const FeatureUpdatesFeed = ({ entries }) => (
       <Header.Subheader>
         This page serves as an announcement hub for new seqr functionality, sourced from this
         &nbsp;
-        <a href="https://github.com/broadinstitute/seqr/discussions/categories/feature-updates">GitHub Discussion</a>
+        <a href="https://github.com/populationgenomics/seqr/discussions/categories/feature-updates">GitHub Discussion</a>
         .
       </Header.Subheader>
     </Header>


### PR DESCRIPTION
Links to the populationgenomics github discussions page. We can turn this into our own feature updates blog, instead of the Broad Institute's seqr updates. 

This PR into staging will allow us to see and test our blog through the seqr-staging ui @ https://seqr-staging.populationgenomics.org.au/feature_updates

