### PR TITLE
Update FEED_URL to use popgen github discussion

### DIFF
--- a/seqr/views/apis/feature_updates_api.py
+++ b/seqr/views/apis/feature_updates_api.py
@@ -6,7 +6,7 @@ import requests
 from seqr.views.utils.json_utils import create_json_response
 
 FEED_URL = (
-    "https://github.com/broadinstitute/seqr/discussions/categories/feature-updates.atom"
+    "https://github.com/populationgenomics/seqr/discussions/categories/feature-updates.atom"
 )
 TIMEOUT = 5
 

--- a/ui/pages/Public/components/FeatureUpdates.jsx
+++ b/ui/pages/Public/components/FeatureUpdates.jsx
@@ -13,9 +13,9 @@ const getDateFromDateStr = dateStr => (
 const FeatureUpdatesFeed = ({ entries }) => (
   <div>
     <Header key="header" dividing size="huge">
-      Feature Updates
+      CPG Updates
       <Header.Subheader>
-        This page serves as an announcement hub for new seqr functionality, sourced from this
+        This page serves as an announcement hub for CPG seqr updates, sourced from this
         &nbsp;
         <a href="https://github.com/populationgenomics/seqr/discussions/categories/feature-updates">GitHub Discussion</a>
         .

--- a/ui/shared/components/page/Header.jsx
+++ b/ui/shared/components/page/Header.jsx
@@ -28,7 +28,7 @@ const PageHeader = React.memo(({ user, onSubmit }) => (
       <Menu.Item key="awesomebar" fitted="vertically"><AwesomeBar newWindow inputwidth="350px" /></Menu.Item>,
     ] : null }
     <Menu.Item key="spacer" position="right" />
-    <Menu.Item key="feature_updates" as={Link} to={FEATURE_UPDATES_PATH} content="Feature Updates (NEW)" />
+    <Menu.Item key="feature_updates" as={Link} to={FEATURE_UPDATES_PATH} content="CPG seqr Updates" />
     {Object.keys(user).length ? [
       <Dropdown
         item


### PR DESCRIPTION
The feature updates UI page calls the endpoint `/api/feature_updates` to fetch the content. This PR updates the source URL in the feature updates api so the feed uses the popgen seqr github discussion, not the broadinstitute one.

This also makes me understand that we will need to create posts in the github discussion page under the category "feature updates" for them to show up here, like how the broad does it:
https://github.com/broadinstitute/seqr/discussions/categories/feature-updates

We don't currently have a feature updates category in our discussion space, so we'll have to make that and add some posts