### PR TITLE
Update IGV reference URLs to new s3 path

### DIFF
--- a/ui/shared/components/panel/family/constants.js
+++ b/ui/shared/components/panel/family/constants.js
@@ -93,15 +93,15 @@ const REFERENCE_URLS = [
     baseUrl: `${BASE_REFERENCE_URL}/s3`,
     path: {
       37: 'igv.broadinstitute.org/genomes/seq/hg19/cytoBand.txt',
-      38: 'igv.org.genomes/hg38/annotations/cytoBandIdeo.txt.gz',
+      38: 'igv-genepattern-org/genomes/hg38/cytoBandIdeo.txt.gz',
     },
   },
   {
     key: 'aliasURL',
-    baseUrl: `${BASE_REFERENCE_URL}/s3/igv.org.genomes`,
+    baseUrl: `${BASE_REFERENCE_URL}/s3`,
     path: {
       37: 'hg19/hg19_alias.tab',
-      38: 'hg38/hg38_alias.tab',
+      38: 'igv-genepattern-org/genomes/hg38/hg38_alias.tab',
     },
   },
 ]
@@ -121,10 +121,10 @@ const REFERENCE_TRACKS = [
   {
     name: 'Refseq',
     indexPostfix: 'tbi',
-    baseUrl: `${BASE_REFERENCE_URL}/s3/igv.org.genomes`,
+    baseUrl: `${BASE_REFERENCE_URL}`,
     path: {
-      37: 'hg19/refGene.sorted.txt.gz',
-      38: 'hg38/refGene.sorted.txt.gz',
+      37: 's3/igv.org.genomes/hg19/refGene.sorted.txt.gz',
+      38: 's3/igv-genepattern-org/genomes/hg38/ncbiRefSeq.txt.gz',
     },
     format: 'refgene',
     visibilityWindow: -1,


### PR DESCRIPTION
Updates the igv publicly hosted reference file URLs to use the new `igv-genepattern-org` url prefix. 