### PR TITLE
Update Dockerfile - remove copy /static build step

### DIFF
--- a/deploy/docker/seqr/Dockerfile
+++ b/deploy/docker/seqr/Dockerfile
@@ -22,7 +22,6 @@ COPY admin /app/seqr/admin
 COPY matchmaker /app/seqr/matchmaker
 COPY reference_data /app/seqr/reference_data
 COPY seqr /app/seqr/seqr
-COPY static ui/dist /app/seqr/static/
 COPY ui/dist /app/seqr/ui/dist
 COPY panelapp /app/seqr/panelapp
 COPY wsgi.py settings.py manage.py deploy/docker/seqr/entrypoint.sh deploy/docker/seqr/init_db.sh deploy/docker/seqr/config/ /app/seqr/


### PR DESCRIPTION
After the upstream merge (#245), [the deploy action failed](https://github.com/populationgenomics/seqr/actions/runs/10804071058/job/29968937657). It looks like we need to remove this step from the Dockerfile where the `static` directory is copied around.

Upstream, the Broad removed this step in July: https://github.com/broadinstitute/seqr/commit/89aeb5abe0851a07aa7890b54a04102b9c1fbc6d

The reason this wasn't caught during the merge is because our Dockerfile is very different from the Dockerfile used in the Broad's seqr deploy. It wasn't clear at the time of the merge that this change needed to be brought across. 
Hopefully this resolves the deploy action failure.