### PR TITLE
Management command to export tsv of CPG ID to proj/fam/indiv

### DIFF
--- a/seqr/management/commands/export_cpg_id_map.py
+++ b/seqr/management/commands/export_cpg_id_map.py
@@ -1,7 +1,6 @@
 from django.core.management.base import BaseCommand
 
 import csv
-from datetime import datetime
 from seqr.models import Sample
 
 import logging
@@ -15,9 +14,7 @@ class Command(BaseCommand):
     )
 
     def handle(self, *args, **options):
-        outfile_name = (
-            f'/app/seqr/cpg_id_map_{datetime.now().strftime("%Y-%m-%dT%H:%M:%S")}'
-        )
+        outfile_name = '/app/seqr/cpg_id_map.tsv'
 
         # Get all the active samples
         samples = Sample.objects.filter(is_active=True)

--- a/seqr/management/commands/export_cpg_id_map.py
+++ b/seqr/management/commands/export_cpg_id_map.py
@@ -1,0 +1,60 @@
+from django.core.management.base import BaseCommand
+
+import csv
+from datetime import datetime
+from seqr.models import Sample
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = (
+        "Export a tsv file with the cpg_id to individual/family/project_guid mappings"
+    )
+
+    def handle(self, *args, **options):
+        outfile_name = (
+            f'/app/seqr/cpg_id_map_{datetime.now().strftime("%Y-%m-%dT%H:%M:%S")}'
+        )
+
+        # Get all the active samples
+        samples = Sample.objects.filter(is_active=True)
+
+        logger.info(f"Exporting {len(samples)} active samples to a tsv file")
+
+        sample_id_to_project_guid = {}
+        sample_id_to_family_guid = {}
+        sample_id_to_individual_id = {}
+
+        for sample in samples:
+            sample_id = sample.sample_id
+            individual_id = sample.individual.individual_id
+            family_guid = sample.individual.family.guid
+            project_guid = sample.individual.family.project.guid
+
+            if sample_id not in sample_id_to_project_guid:
+                sample_id_to_project_guid[sample_id] = project_guid
+            if sample_id not in sample_id_to_family_guid:
+                sample_id_to_family_guid[sample_id] = family_guid
+            if sample_id not in sample_id_to_individual_id:
+                sample_id_to_individual_id[sample_id] = individual_id
+
+        # Write the sample_id_to_individual/family/project_guid dicts to a tsv file
+        with open(outfile_name, "w") as f:
+            writer = csv.writer(f, delimiter="\t")
+            writer.writerow(["cpg_id", "individual_id", "family_guid", "project_guid"])
+            for sample_id, project_guid in sample_id_to_project_guid.items():
+                writer.writerow(
+                    [
+                        sample_id,
+                        sample_id_to_individual_id[sample_id],
+                        sample_id_to_family_guid[sample_id],
+                        project_guid,
+                    ]
+                )
+
+        logger.info(
+            f"Exported mappings for {len(samples)} active samples to {outfile_name}"
+        )


### PR DESCRIPTION
This PR adds a new management command that extracts all active samples from the seqr instance and dumps them into a tsv with the columns
`"cpg_id", "individual_id", "family_guid", "project_guid"`

The tsv file is saved to a location within the docker container running the seqr instance: `/app/seqr/cpg_id_map.tsv`. 

---

- _**How do we then get the tsv out of the container so we can actually use it?**_

From inside the VM, files can be copied to the VM disk from the docker container with the `docker cp` command.
```
CONTAINER_ID="seqr_container_id"
CONTAINER_PATH="/app/seqr/cpg_id_map.tsv"
VM_PATH="./cpg_id_map.tsv"

sudo docker cp $CONTAINER_ID:$CONTAINER_PATH $VM_PATH
```

---

- _**Then how do we get the file off the VM disk and into cloud storage (or even local storage)?**_


**Copying to cloud storage**
The VM has `gsutil` installed and is auth'd in as the environment (prod/staging) service account, so we can copy files from the VM into the main or test bucket.

```
gsutil cp cpg_id_map.tsv gs://<seqr-main|test-bucket>/cpg_id_map.tsv
```

---

**Copying to local storage**
If we are SSH'd in to the VM from a local terminal, we can use `gcloud compute scp`
```
PROJECT_ID="seqr_GCP_project_id"
ZONE="seqr_GCE_VM_zone"
INSTANCE_NAME="seqr_GCE_VM_name"
VM_PATH="./cpg_id_map.tsv"
LOCAL_PATH="./cpg_id_map.tsv"

gcloud compute scp --project $PROJECT_ID --zone $ZONE $INSTANCE_NAME:$VM_PATH $LOCAL_PATH
```

OR, if we are SSH'd into the VM through a GCE "SSH-in-browser" connection, you can click the "DOWNLOAD FILE" button, and enter the path to the file, i.e. `/home/username/cpg_id_map.tsv`

---

Something that's great about this whole process is that most of it could be automated using a Cloud Run job that runs daily/weekly/monthly. This way we wouldn't have to worry about running the management command and copying the output out of the container into the VM and then into the bucket. We could just go to the fixed bucket location to always have an up to date mapping. 