### PR TITLE
Add the User-Agent header to IGV API proxy requests

### DIFF
--- a/seqr/views/apis/igv_api.py
+++ b/seqr/views/apis/igv_api.py
@@ -278,6 +278,8 @@ def igv_genomes_proxy(request, cloud_host, file_path):
     range_header = request.META.get('HTTP_RANGE')
     if range_header:
         headers['Range'] = range_header
+    headers['User-Agent'] = request.META.get('HTTP_USER_AGENT', 'Mozilla/5.0')
+
     if cloud_host == S3_KEY:
         headers.update(convert_django_meta_to_http_headers(request))
 


### PR DESCRIPTION
Add the `User-Agent` header field to the IGV API proxy requests. This allows the curl commands to get files from the S3 buckets to succeed. 

Was initially added in https://github.com/populationgenomics/seqr/pull/239/files, but was mistakenly removed during the upstream merge https://github.com/populationgenomics/seqr/pull/245