### PR TITLE
Add the user-agent header in with a simple default

### DIFF
--- a/seqr/views/apis/igv_api.py
+++ b/seqr/views/apis/igv_api.py
@@ -278,6 +278,7 @@ def igv_genomes_proxy(request, cloud_host, file_path):
     range_header = request.META.get('HTTP_RANGE')
     if range_header:
         headers['Range'] = range_header
+    headers['User-Agent'] = request.META.get('HTTP_USER_AGENT', 'Mozilla/5.0')
 
     genome_response = requests.get(f'{CLOUD_STORAGE_URLS[cloud_host]}/{file_path}', headers=headers, timeout=TIMEOUT)
     proxy_response = HttpResponse(


### PR DESCRIPTION
I think this will actually work, seeing as a curl command in terminal works with this user-agent string, like how we have in prod.

