### PR TITLE
Remove the s3 bucket headers corrections

### DIFF
--- a/seqr/views/apis/data_manager_api_tests.py
+++ b/seqr/views/apis/data_manager_api_tests.py
@@ -497,7 +497,8 @@ class DataManagerAPITest(AirtableTest):
         self.assertDictEqual(response_json['indices'][3], TEST_INDEX_NO_PROJECT_EXPECTED_DICT)
         self.assertDictEqual(response_json['indices'][4], TEST_SV_INDEX_EXPECTED_DICT)
 
-        self.assertListEqual(response_json['errors'], EXPECTED_ERRORS)
+        # sort both of these lists since the list ordering from the response dict is indeterminate
+        self.assertListEqual(sorted(response_json['errors']), sorted(EXPECTED_ERRORS))
 
         self.assertListEqual(response_json['diskStats'], EXPECTED_DISK_ALLOCATION)
         self.assertListEqual(response_json['nodeStats'], EXPECTED_NODE_STATS)

--- a/seqr/views/apis/igv_api.py
+++ b/seqr/views/apis/igv_api.py
@@ -311,9 +311,6 @@ def igv_genomes_proxy(request, cloud_host, file_path):
         headers['Range'] = range_header
     headers['User-Agent'] = request.META.get('HTTP_USER_AGENT', 'Mozilla/5.0')
 
-    if cloud_host == S3_KEY:
-        headers.update(convert_django_meta_to_http_headers(request))
-
     genome_response = requests.get(f'{CLOUD_STORAGE_URLS[cloud_host]}/{file_path}', headers=headers, timeout=TIMEOUT)
     proxy_response = HttpResponse(
         content=genome_response.content,

--- a/seqr/views/apis/igv_api_tests.py
+++ b/seqr/views/apis/igv_api_tests.py
@@ -332,7 +332,7 @@ class IgvAPITest(AnvilAuthenticationTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertDictEqual(json.loads(response.content), expected_body)
         self.assertIsNone(responses.calls[0].request.headers.get('Range'))
-        self.assertEqual(responses.calls[0].request.headers.get('Test-Header'), 'test/value')
+        # self.assertEqual(responses.calls[0].request.headers.get('Test-Header'), 'test/value')
 
         # test with range header proxy
         gs_url = reverse(igv_genomes_proxy, args=['gs', 'test-bucket/foo.fasta'])


### PR DESCRIPTION
OK, after some testing in the reanalysis-dev branch, this is the change needed to get the read viewer working again. With this change, the `igv_genomes_proxy` function will be the same as it is in the main and reanlaysis-dev branches, where it works fine in deployment.

The problem came from this call, which was supposed to be updating the request headers to better interact with the S3 bucket URLs:
```python
if cloud_host == S3_KEY:
    headers.update(convert_django_meta_to_http_headers(request))
```
Where the [`convert_django_meta_to_http_headers`](https://github.com/populationgenomics/seqr/blob/3f7bc58bdc07aee2d61c4e0cc4c583ec592413d9/seqr/views/utils/dataset_utils.py#L627) function is a simple find and replace on the dict keys. 
However, it actually causes a problem with the IGV proxy where the bucket name and file ID all get messed up and we see a bucket name error:
```
NoSuchBucket
The specified bucket does not exist
seqr-staging.populationgenomics.org.au16W3BE...
```

Removing these lines fixes the issue, allowing the [the reference files](https://github.com/populationgenomics/seqr/blob/967e097ae61a722c8f8c3f6bc444705dd926f72a/ui/shared/components/panel/family/constants.js#L96) required for IGV to be pulled.

---

Also updates the `test_igv_genomes_proxy` test to account for the removal of the call to `convert_django_meta_to_http_headers`, and an unrelated fix to the `test_elasticsearch_status` test which was failing 50% of the time due to indeterminate list ordering. 
