### PR TITLE
Add exclude reasons as tag metadata.

### DIFF
--- a/ui/shared/components/panel/view-fields/TagFieldView.jsx
+++ b/ui/shared/components/panel/view-fields/TagFieldView.jsx
@@ -22,10 +22,10 @@ const MetadataFormGroup = styled(Form.Group).attrs({ inline: true })`
   label, .label {
     white-space: nowrap;
   }
-  
+
   .fluid.selection.dropdown {
     width: 100% !important;
-  } 
+  }
 `
 
 const MultiselectField = ({ input, ...props }) => <Multiselect {...input} {...props} />
@@ -54,6 +54,16 @@ const METADATA_FIELD_PROPS = {
     allowAdditions: true,
     addValueOptions: true,
     options: ['Sanger', 'Segregation', 'SV', 'Splicing'].map(value => ({ value })),
+    placeholder: 'Select test types or add your own',
+    ...LIST_FORMAT_PROPS,
+  },
+  'Exclude Type(s)': {
+    width: 16,
+    component: MultiselectField,
+    fluid: true,
+    allowAdditions: true,
+    addValueOptions: true,
+    options: ['Polymorphism', 'artefact', 'No phenotypic fit'].map(value => ({ value })),
     placeholder: 'Select test types or add your own',
     ...LIST_FORMAT_PROPS,
   },

--- a/ui/shared/components/panel/view-fields/TagFieldView.jsx
+++ b/ui/shared/components/panel/view-fields/TagFieldView.jsx
@@ -63,7 +63,7 @@ const METADATA_FIELD_PROPS = {
     fluid: true,
     allowAdditions: true,
     addValueOptions: true,
-    options: ['Polymorphism', 'artefact', 'No phenotypic fit'].map(value => ({ value })),
+    options: ['Polymorphism', 'Artefact', 'No phenotypic fit'].map(value => ({ value })),
     placeholder: 'Select test types or add your own',
     ...LIST_FORMAT_PROPS,
   },


### PR DESCRIPTION
As discussed here: https://centrepopgen.slack.com/archives/C085XN3U58S/p1736915828491199 we have a request to add a new exclude tag with a limited vocab of reasons for the exclusion. Seqr already supports this capability through tag metadata. This will add a new tag metadata "type" that we can use in a tag.