### PR TITLE
Update gh actions in unit-tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -42,18 +42,18 @@ jobs:
           - 5432:5432
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: actions/setup-java@v1
+    - uses: actions/setup-java@v4
       with:
         java-version: '8' # The JDK version needed by hail
         java-package: jdk # (jre, jdk, or jdk+fx) - defaults to jdk
         architecture: x64 # (x64 or x86) - defaults to x64
     - name: Use pip cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: pip-${{ hashFiles('**/requirements*.txt') }}
@@ -89,9 +89,9 @@ jobs:
         node-version: [14]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -51,6 +51,7 @@ jobs:
       with:
         java-version: '8' # The JDK version needed by hail
         java-package: jdk # (jre, jdk, or jdk+fx) - defaults to jdk
+        distribution: 'temurin'
         architecture: x64 # (x64 or x86) - defaults to x64
     - name: Use pip cache
       uses: actions/cache@v4


### PR DESCRIPTION
Use the latest versions of the actions before the old versions become deprecated.