### PR TITLE
Update panelapp URL to new panelapp-aus URL

### DIFF
--- a/deploy/docker/seqr/deploy_cloudrun_jobs.sh
+++ b/deploy/docker/seqr/deploy_cloudrun_jobs.sh
@@ -70,7 +70,7 @@ gcloud beta run jobs create \
    ${ENV_NAME}-reference-import-panels \
    --image=${IMAGE} \
    --task-timeout 3600 \
-   --command=python --args="-u,manage.py,import_all_panels,https://panelapp.agha.umccr.org/api/v1,--label=AU" \
+   --command=python --args="-u,manage.py,import_all_panels,https://panelapp-aus.org/api/v1,--label=AU" \
    --region=australia-southeast1 \
    --service-account=${SERVICE_ACCOUNT} \
    --vpc-connector=projects/seqr-308602/locations/australia-southeast1/connectors/seqr-cloud-run-to-sql \

--- a/seqr/fixtures/1kg_project.json
+++ b/seqr/fixtures/1kg_project.json
@@ -2364,7 +2364,7 @@
     "status": "public",
     "version": "1.0",
     "version_created": "2018-04-28T00:03:25.347Z",
-    "url": "https://panelapp.agha.umccr.org/api/v1/panels/254/genes"
+    "url": "https://panelapp-aus.org/api/v1/panels/254/genes"
   }
 },
 {

--- a/ui/shared/utils/panelAppUtils.test.ts
+++ b/ui/shared/utils/panelAppUtils.test.ts
@@ -55,15 +55,15 @@ describe('Test moiToMoiInitials()', () => {
 })
 
 const panelAppData = [{
-  url: 'https://panelapp.agha.umccr.org/api/v1/panels/40/genes',
+  url: 'https://panelapp-aus.org/api/v1/panels/40/genes',
   panel: 40,
   gene: 'SLC2A1',
-  result: 'https://panelapp.agha.umccr.org/panels/40/gene/SLC2A1',
+  result: 'https://panelapp-aus.org/panels/40/gene/SLC2A1',
 }, {
-  url: 'https://panelapp.agha.umccr.org/api/v1/panels/40/genes',
+  url: 'https://panelapp-aus.org/api/v1/panels/40/genes',
   panel: 40,
   gene: 'SLC1A3',
-  result: 'https://panelapp.agha.umccr.org/panels/40/gene/SLC1A3',
+  result: 'https://panelapp-aus.org/panels/40/gene/SLC1A3',
 }, {
   url: 'https://panelapp.genomicsengland.co.uk/api/v1',
   panel: 486,


### PR DESCRIPTION
Copies the changes from this PR, which was merged into staging to update the PanelApp URLs: https://github.com/populationgenomics/seqr/pull/263

- Also requires updating the Cloud Run job `prod-reference-import-panels` to point to the new URL, and then running it
- Also requires updating the gene lists in each seqr project, either through admin panel or by removing the old gene lists and then adding the updated versions.