### PR TITLE
Cardinal seqr

### DIFF
--- a/ui/pages/Public/components/FeatureUpdates.jsx
+++ b/ui/pages/Public/components/FeatureUpdates.jsx
@@ -13,9 +13,9 @@ const getDateFromDateStr = dateStr => (
 const FeatureUpdatesFeed = ({ entries }) => (
   <div>
     <Header key="header" dividing size="huge">
-      CPG Updates
+      CaRDinal Updates
       <Header.Subheader>
-        This page serves as an announcement hub for CPG seqr updates, sourced from this
+        This page serves as an announcement hub for CaRDinal seqr updates, sourced from this
         &nbsp;
         <a href="https://github.com/populationgenomics/seqr/discussions/categories/feature-updates">GitHub Discussion</a>
         .

--- a/ui/pages/Public/components/LandingPage.jsx
+++ b/ui/pages/Public/components/LandingPage.jsx
@@ -106,7 +106,7 @@ const LandingPage = () => (
         </List.Item>
         <List.Item>
           Please use the &nbsp;
-          <Anchor href="http://github.com/populationgenomics/seqr/issues">CPG&apos;s GitHub issues page</Anchor>
+          <Anchor href="http://github.com/populationgenomics/seqr/issues">CaRDinal seqr GitHub issues page</Anchor>
           &nbsp; to submit bug reports or feature requests
         </List.Item>
         <List.Item>

--- a/ui/pages/Public/components/PrivacyPolicy.jsx
+++ b/ui/pages/Public/components/PrivacyPolicy.jsx
@@ -3,7 +3,7 @@ import { Header, Segment, List } from 'semantic-ui-react'
 
 export default () => (
   <Segment basic padded="very">
-    <Header dividing content="CPG seqr Privacy Policy" subheader="Last Updated 13-MAY-2021" size="huge" />
+    <Header dividing content="CaRDinal seqr Privacy Policy" subheader="Last Updated 13-MAY-2021" size="huge" />
     Please read these terms and conditions carefully before using this site.
     <br />
 

--- a/ui/pages/Public/components/TermsOfService.jsx
+++ b/ui/pages/Public/components/TermsOfService.jsx
@@ -3,7 +3,7 @@ import { Header, Segment, List } from 'semantic-ui-react'
 
 export default () => (
   <Segment basic padded="very">
-    <Header dividing content="CPG seqr Terms Of Service" subheader="Last Updated 13-MAY-2021" size="huge" />
+    <Header dividing content="CaRDinal seqr Terms Of Service" subheader="Last Updated 13-MAY-2021" size="huge" />
 
     Please read these terms of service carefully before using this site.
     <br />

--- a/ui/pages/SummaryData/components/ExternalAnalysis.jsx
+++ b/ui/pages/SummaryData/components/ExternalAnalysis.jsx
@@ -17,7 +17,7 @@ const UPLOAD_FIELDS = [
     component: Select,
     options: [
       ...FAMILY_ANALYSED_BY_DATA_TYPES.map(([value, text]) => ({ value, text })),
-      { value: 'AIP' }, { value: 'CPG: Full Talos report' },
+      { value: 'AIP' }, { value: 'CaRDinal: Full Talos report' },
     ],
     validate: validators.required,
   },

--- a/ui/shared/components/panel/view-fields/TagFieldView.jsx
+++ b/ui/shared/components/panel/view-fields/TagFieldView.jsx
@@ -63,7 +63,7 @@ const METADATA_FIELD_PROPS = {
     fluid: true,
     allowAdditions: true,
     addValueOptions: true,
-    options: ['Polymorphism', 'Artefact', 'No phenotypic fit'].map(value => ({ value })),
+    options: ['Polymorphism', 'Artefact', 'No phenotypic fit', 'Irrelevant expression', 'Does not segregate'].map(value => ({ value })),
     placeholder: 'Select test types or add your own',
     ...LIST_FORMAT_PROPS,
   },


### PR DESCRIPTION
1. Changes "CPG" to "CaRDinal" in some aspects of the front-end, to better publicize the name "CaRDinal seqr" (as opposed to "CPG seqr")
2. Adds two new exclude reasons to the "Excluded" tag reasons drop down menu.

Both of these minor changes were requested to be added before the imminent production release (https://github.com/populationgenomics/seqr/pull/247).