### PR TITLE
Display gnomAD frequencies as gnomAD v3, not v4

### DIFF
--- a/ui/shared/components/panel/variants/Frequencies.jsx
+++ b/ui/shared/components/panel/variants/Frequencies.jsx
@@ -191,7 +191,7 @@ const POPULATIONS = [
     field: 'gnomad_genomes',
     fieldTitle: 'gnomAD genomes',
     titleContainer: gnomadLink,
-    esVersion: 'v4',
+    esVersion: 'v3',
     conditionalQueryParams: populations => (populations.seqr ? GNOMAD_URL_INFO.queryParams : { [GENOME_VERSION_38]: 'dataset=gnomad_r4' }),
     precision: 3,
     ...GNOMAD_URL_INFO,


### PR DESCRIPTION
Partially reverts https://github.com/populationgenomics/seqr/pull/260

The variant search results displays the text "gnomAD v4" next to the allele frequency that's in our callsets. At present, our callsets contain gnomAD v3 frequencies, not v4. Until we update this in our callsets, the text displayed in seqr should say "gnomAD v3", to avoid any confusion.