### PR TITLE
Remove reliance on igv-genepattern-org s3 files, use ucsc instead

### DIFF
--- a/seqr/views/apis/igv_api.py
+++ b/seqr/views/apis/igv_api.py
@@ -24,6 +24,7 @@ S3_KEY = 's3'
 CLOUD_STORAGE_URLS = {
     S3_KEY: 'https://s3.amazonaws.com',
     'gs': GS_STORAGE_URL,
+    'ucsc': 'https://hgdownload.soe.ucsc.edu',
 }
 TIMEOUT = 300
 

--- a/ui/shared/components/panel/family/constants.js
+++ b/ui/shared/components/panel/family/constants.js
@@ -90,18 +90,18 @@ const REFERENCE_URLS = [
   },
   {
     key: 'cytobandURL',
-    baseUrl: `${BASE_REFERENCE_URL}/s3`,
+    baseUrl: BASE_REFERENCE_URL,
     path: {
-      37: 'igv.broadinstitute.org/genomes/seq/hg19/cytoBand.txt',
-      38: 'igv-genepattern-org/genomes/hg38/cytoBandIdeo.txt.gz',
+      37: 's3/igv.broadinstitute.org/genomes/seq/hg19/cytoBand.txt',
+      38: 'ucsc/goldenPath/hg38/database/cytoBandIdeo.txt.gz',
     },
   },
   {
     key: 'aliasURL',
-    baseUrl: `${BASE_REFERENCE_URL}/s3`,
+    baseUrl: BASE_REFERENCE_URL,
     path: {
-      37: 'hg19/hg19_alias.tab',
-      38: 'igv-genepattern-org/genomes/hg38/hg38_alias.tab',
+      37: 's3/hg19/hg19_alias.tab',
+      38: 'ucsc/goldenPath/hg38/bigZips/hg38.chromAlias.txt',
     },
   },
 ]
@@ -109,7 +109,7 @@ const REFERENCE_URLS = [
 const REFERENCE_TRACKS = [
   {
     name: 'Gencode v32',
-    indexPostfix: 'tbi',
+    indexPostfix: { 37: 'tbi', 38: 'tbi' },
     baseUrl: 'gs://seqr-reference-data',
     path: {
       37: 'GRCh37/gencode/gencode.v32lift37.annotation.sorted.bed.gz',
@@ -120,11 +120,11 @@ const REFERENCE_TRACKS = [
   },
   {
     name: 'Refseq',
-    indexPostfix: 'tbi',
-    baseUrl: `${BASE_REFERENCE_URL}`,
+    indexPostfix: { 37: 'tbi', 38: null },
+    baseUrl: BASE_REFERENCE_URL,
     path: {
       37: 's3/igv.org.genomes/hg19/refGene.sorted.txt.gz',
-      38: 's3/igv-genepattern-org/genomes/hg38/ncbiRefSeq.txt.gz',
+      38: 'ucsc/goldenPath/hg38/database/ncbiRefSeq.txt.gz',
     },
     format: 'refgene',
     visibilityWindow: -1,
@@ -138,7 +138,7 @@ export const REFERENCE_LOOKUP = ['37', '38'].reduce((acc, genome) => ({
     id: GENOME_VERSION_DISPLAY_LOOKUP[GENOME_VERSION_LOOKUP[genome]],
     tracks: REFERENCE_TRACKS.map(({ baseUrl, path, indexPostfix, ...track }) => ({
       url: `${baseUrl}/${path[genome]}`,
-      indexURL: indexPostfix ? `${baseUrl}/${path[genome]}.${indexPostfix}` : null,
+      indexURL: indexPostfix[genome] ? `${baseUrl}/${path[genome]}.${indexPostfix[genome]}` : null,
       ...track,
     })),
     ...REFERENCE_URLS.reduce((acc2, { key, baseUrl, path }) => ({ ...acc2, [key]: `${baseUrl}/${path[genome]}` }), {}),


### PR DESCRIPTION
Looks like the public facing side of genepattern is shutting down in about 2 weeks due to lack of funding (see https://www.genepattern.org/)

We can get most of the same files from UCSC. There's some small changes required to how we get the refseq file as there's no .tbi index available from UCSC so we don't want to try and download it (it's not necessary anyway).


| Resource | Before (genepattern S3, dying) | After (UCSC) |
|---|---|---|
| cytoband | `s3.amazonaws.com/igv-genepattern-org/genomes/hg38/cytoBandIdeo.txt.gz` | `hgdownload.soe.ucsc.edu/goldenPath/hg38/database/cytoBandIdeo.txt.gz` |
| alias | `s3.amazonaws.com/igv-genepattern-org/genomes/hg38/hg38_alias.tab` | `hgdownload.soe.ucsc.edu/goldenPath/hg38/bigZips/hg38.chromAlias.txt` |
| Refseq track | `s3.amazonaws.com/igv-genepattern-org/genomes/hg38/ncbiRefSeq.txt.gz` (+`.tbi`) | `hgdownload.soe.ucsc.edu/goldenPath/hg38/database/ncbiRefSeq.txt.gz` (no index) |


**Need to validate this fix in staging env before deploying to main.**