### PR TITLE
Update Dockerfile to build from slim-bookworm

### DIFF
--- a/deploy/docker/seqr/Dockerfile
+++ b/deploy/docker/seqr/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim-buster
+FROM python:3.9-slim-bookworm
 
 ARG SEQR_SERVICE_PORT
 ENV SEQR_SERVICE_PORT=$SEQR_SERVICE_PORT
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libgtk2-perl libdbi-perl libtk-perl libsort-naturally-perl && \
     # Google Cloud SDK
     echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
     apt-get update && apt-get install -y google-cloud-sdk && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     pip install --no-cache-dir -r /app/seqr/requirements.txt


### PR DESCRIPTION
Debian 10 "buster" is EOL nd its packages were moved to archive.debian.org, so the build no longer works and [404s](https://github.com/populationgenomics/seqr/actions/runs/26555168412/job/78225384286)

1. Bump the base image off buster. `python:3.9-slim-bookworm` (Debian 12) is supported until June 2028 and is what python:3.9-slim aliases to today.
2. Modernize the gcloud apt-key install. `apt-key` is removed in bookworm, so the existing `curl … | apt-key … add -` would fail on the new base. The line above it already uses the modern `signed-by=/usr/share/keyrings/cloud.google.gpg` style, so we just need to write the keyring with `gpg --dearmor` instead.