### PR TITLE
Remove EOL package installs in Dockerfile

### DIFF
--- a/deploy/docker/seqr/Dockerfile
+++ b/deploy/docker/seqr/Dockerfile
@@ -8,9 +8,7 @@ WORKDIR /app/seqr
 COPY requirements.txt /app/seqr/
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    apt-transport-https ca-certificates curl gnupg \
-    # install dependencies of the HaploPainter.pl script used to generate static pedigree images
-    libgtk2-perl libdbi-perl libtk-perl libsort-naturally-perl && \
+    apt-transport-https ca-certificates curl gnupg && \
     # Google Cloud SDK
     echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \


### PR DESCRIPTION
`libgtk2-perl` doesn't exist on bookworm. Debian dropped that package because GTK2 is end-of-life (it was removed during the bullseye → bookworm transition).

The comment about HaploPainter.pl is also extremely stale, there are no such perl scripts in use, so these are safe to remove