### PR TITLE
Update HPO term parsing for new OBO release format

### DIFF
--- a/reference_data/management/commands/update_human_phenotype_ontology.py
+++ b/reference_data/management/commands/update_human_phenotype_ontology.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 from tqdm import tqdm
 
 from django.db import transaction
@@ -79,7 +80,8 @@ def parse_obo_file(file_iterator):
                 'is_category': False,
             }
         elif line.startswith("is_a: "):
-            is_a = value.split(" ! ")[0]
+            # OBO format: "<id>" optionally followed by " ! <label>" and/or trailing " {<modifiers>}"
+            is_a = re.sub(r'\s*\{[^}]*\}\s*$', '', value).split(' ! ')[0].strip()
             if is_a == "HP:0000118":
                 hpo_id_to_record[hpo_id]['is_category'] = True
             hpo_id_to_record[hpo_id]['parent_id'] = is_a

--- a/reference_data/management/tests/update_hpo_tests.py
+++ b/reference_data/management/tests/update_hpo_tests.py
@@ -178,7 +178,7 @@ class UpdateHpoTest(TestCase):
         call_command('update_human_phenotype_ontology')
 
         calls = [
-            mock.call('Deleting HumanPhenotypeOntology table with 12 records and creating new table with 5 records'),
+            mock.call('Deleting HumanPhenotypeOntology table with 12 records and creating new table with 7 records'),
             mock.call('Done'),
         ]
         mock_logger.info.assert_has_calls(calls)

--- a/reference_data/management/tests/update_hpo_tests.py
+++ b/reference_data/management/tests/update_hpo_tests.py
@@ -135,20 +135,20 @@ EXPECTED_DB_DATA = {
         'category_id': None
     },
     'HP:9999001': {
-        'is_category': False,
+        'is_category': True,
         'definition': None,
         'name': 'trailer with xref only',
         'parent_id': 'HP:0000118',
         'hpo_id': 'HP:9999001',
-        'category_id': None,
+        'category_id': 'HP:9999001',
     },
     'HP:9999002': {
-        'is_category': False,
+        'is_category': True,
         'definition': None,
         'name': 'trailer with label and xref',
         'parent_id': 'HP:0000118',
         'hpo_id': 'HP:9999002',
-        'category_id': None,
+        'category_id': 'HP:9999002',
     },
 }
 

--- a/reference_data/management/tests/update_hpo_tests.py
+++ b/reference_data/management/tests/update_hpo_tests.py
@@ -81,6 +81,7 @@ PHO_DATA = [
     'synonym: "Head and neck abnormality" EXACT layperson []\n',
     'xref: UMLS:C4021817\n',
     'is_a: HP:0000118 ! Phenotypic abnormality\n',
+    '\n',
     '[Term]\n', # is_a with xref and no label
     'id: HP:9999001\n',
     'name: trailer with xref only\n',
@@ -90,7 +91,6 @@ PHO_DATA = [
     'id: HP:9999002\n',
     'name: trailer with label and xref\n',
     'is_a: HP:0000118 ! Phenotypic abnormality {xref="PMID:31677808"}\n',
-    '\n',
 ]
 
 EXPECTED_DB_DATA = {
@@ -133,7 +133,23 @@ EXPECTED_DB_DATA = {
         'parent_id': 'HP:0000001',
         'hpo_id': 'HP:0000003',
         'category_id': None
-    }
+    },
+    'HP:9999001': {
+        'is_category': False,
+        'definition': None,
+        'name': 'trailer with xref only',
+        'parent_id': 'HP:0000118',
+        'hpo_id': 'HP:9999001',
+        'category_id': None,
+    },
+    'HP:9999002': {
+        'is_category': False,
+        'definition': None,
+        'name': 'trailer with label and xref',
+        'parent_id': 'HP:0000118',
+        'hpo_id': 'HP:9999002',
+        'category_id': None,
+    },
 }
 
 class UpdateHpoTest(TestCase):

--- a/reference_data/management/tests/update_hpo_tests.py
+++ b/reference_data/management/tests/update_hpo_tests.py
@@ -81,6 +81,16 @@ PHO_DATA = [
     'synonym: "Head and neck abnormality" EXACT layperson []\n',
     'xref: UMLS:C4021817\n',
     'is_a: HP:0000118 ! Phenotypic abnormality\n',
+    '[Term]\n', # is_a with xref and no label
+    'id: HP:9999001\n',
+    'name: trailer with xref only\n',
+    'is_a: HP:0000118 {xref="PMID:31677808"}\n',
+    '\n',
+    '[Term]\n', # is_a with label and xref
+    'id: HP:9999002\n',
+    'name: trailer with label and xref\n',
+    'is_a: HP:0000118 ! Phenotypic abnormality {xref="PMID:31677808"}\n',
+    '\n',
 ]
 
 EXPECTED_DB_DATA = {

--- a/reference_data/management/tests/update_hpo_tests.py
+++ b/reference_data/management/tests/update_hpo_tests.py
@@ -189,7 +189,7 @@ class UpdateHpoTest(TestCase):
         call_command('update_human_phenotype_ontology', tmp_file)
 
         calls = [
-            mock.call('Deleting HumanPhenotypeOntology table with 5 records and creating new table with 5 records'),
+            mock.call('Deleting HumanPhenotypeOntology table with 7 records and creating new table with 7 records'),
             mock.call('Done'),
         ]
         mock_logger.info.assert_has_calls(calls)


### PR DESCRIPTION
# Fix for HPO.obo file parsing causing the `update-hpo-terms` Cloudrun jobs to fail 


_Based on the changes drafted for new seqr here: https://github.com/populationgenomics/cardinal-seqr/pull/10_


## Parsing OBO trailing modifier blocks in HPO terms

### Problem
New HPO releases now emit lines like:
```
is_a: HP:0032162 {xref="PMID:31677808"}
```
The parser strips OBO's  `! human-readable label` suffix, but not the OBO trailing annotation block `{xref="..."}`. 
(or in combination: `is_a: HP:0032162 ! Childhood onset {xref="PMID:31677808"}`)

After `.split(' ! ')[0]` we get the literal string `HP:0032162 {xref="PMID:31677808"}` and store that as `parent_id`. Later, `_get_category_id` walks the parent chain and looks up that string in `parent_id_map`. It's not a real key (only the clean `HP:0032162 is`), so line 236 raises:
```
ValueError('Strange id: %s' % hpo_id)
```

### Fix
In `get_file_iterator`, strip the trailing `{...}` annotation block in addition to ` ! label`. 
- Regex-tidy: `re.sub(r'\s*\{[^}]*\}\s*$', '', value.split(' ! ')[0]).strip()`

Also add a regression test in `update_hpo_tests.py` using fixture lines with `{xref=...}` trailers (both alone and combined with ` ! label`).

The OBO 1.4 spec allows trailing modifiers on basically any clause that takes a target ID (`is_a`, `intersection_of`, `union_of`, `relationship`, etc.). We currently only parse `is_a`, so that's the only line to fix.

### Testing

```python
>>> import re

>>> # Test with expected ' ! ' and unexpected suffix term '{xref="..."}'
>>> line = 'is_a: HP:0000118 ! Phenotypic abnormality {xref="PMID:31677808"}\n'
>>> value = " ".join(line.split(" ")[1:])
>>> is_a = re.sub(r'\s*\{[^}]*\}\s*$', '', value).split(' ! ')[0].strip()
>>> print(is_a)
HP:0000118

>>> # Test with just unexpected suffix term '{xref="..."}'
>>> line = 'is_a: HP:0000118 {xref="PMID:31677808"}\n'
>>> value = " ".join(line.split(" ")[1:])
>>> is_a = re.sub(r'\s*\{[^}]*\}\s*$', '', value).split(' ! ')[0].strip()
>>> print(is_a)
HP:0000118
```