### PR TITLE
Fix HPO parsing for OBO 1.4 - round 2

### DIFF
--- a/reference_data/management/commands/update_human_phenotype_ontology.py
+++ b/reference_data/management/commands/update_human_phenotype_ontology.py
@@ -80,8 +80,11 @@ def parse_obo_file(file_iterator):
                 'is_category': False,
             }
         elif line.startswith("is_a: "):
-            # OBO format: "<id>" optionally followed by " ! <label>" and/or trailing " {<modifiers>}"
-            is_a = re.sub(r'\s*\{[^}]*\}\s*$', '', value).split(' ! ')[0].strip()
+            # Match the HPO id directly; OBO modifiers ({...}) and comments (! ...) may appear in any order around it.
+            match = re.search(r'HP:\d{7}', value)
+            if not match:
+                raise ValueError("is_a line missing HPO id: %s" % line)
+            is_a = match.group(0)
             if is_a == "HP:0000118":
                 hpo_id_to_record[hpo_id]['is_category'] = True
             hpo_id_to_record[hpo_id]['parent_id'] = is_a

--- a/reference_data/management/tests/update_hpo_tests.py
+++ b/reference_data/management/tests/update_hpo_tests.py
@@ -87,10 +87,15 @@ PHO_DATA = [
     'name: trailer with xref only\n',
     'is_a: HP:0000118 {xref="PMID:31677808"}\n',
     '\n',
-    '[Term]\n', # is_a with label and xref
+    '[Term]\n', # is_a with label and xref (label then modifier)
     'id: HP:9999002\n',
     'name: trailer with label and xref\n',
     'is_a: HP:0000118 ! Phenotypic abnormality {xref="PMID:31677808"}\n',
+    '\n',
+    '[Term]\n', # is_a with xref then label (OBO 1.4 standard ordering)
+    'id: HP:9999003\n',
+    'name: trailer with xref then label\n',
+    'is_a: HP:0000118 {xref="PMID:31677808"} ! Phenotypic abnormality\n',
 ]
 
 EXPECTED_DB_DATA = {
@@ -150,6 +155,14 @@ EXPECTED_DB_DATA = {
         'hpo_id': 'HP:9999002',
         'category_id': 'HP:9999002',
     },
+    'HP:9999003': {
+        'is_category': True,
+        'definition': None,
+        'name': 'trailer with xref then label',
+        'parent_id': 'HP:0000118',
+        'hpo_id': 'HP:9999003',
+        'category_id': 'HP:9999003',
+    },
 }
 
 class UpdateHpoTest(TestCase):
@@ -178,7 +191,7 @@ class UpdateHpoTest(TestCase):
         call_command('update_human_phenotype_ontology')
 
         calls = [
-            mock.call('Deleting HumanPhenotypeOntology table with 12 records and creating new table with 7 records'),
+            mock.call('Deleting HumanPhenotypeOntology table with 12 records and creating new table with 8 records'),
             mock.call('Done'),
         ]
         mock_logger.info.assert_has_calls(calls)
@@ -189,7 +202,7 @@ class UpdateHpoTest(TestCase):
         call_command('update_human_phenotype_ontology', tmp_file)
 
         calls = [
-            mock.call('Deleting HumanPhenotypeOntology table with 7 records and creating new table with 7 records'),
+            mock.call('Deleting HumanPhenotypeOntology table with 8 records and creating new table with 8 records'),
             mock.call('Done'),
         ]
         mock_logger.info.assert_has_calls(calls)


### PR DESCRIPTION
# Follow up to #288

## The problem

The regex assumed `{modifier}` comes after ` ! comment`, but OBO 1.4 spec puts the modifier before the comment, and the real HPO file uses the standard ordering. With a line like `is_a: HP:0032162 {xref="PMID:31677808"} ! Phenotypic abnormality`, the anchored-to-end regex didn't match, `split(' ! ')[0]` returned `HP:0032162 {xref="..."}`, and that string was stored as the `parent_id`, leading to errors.

## The fix

- `re.search(r'HP:\d{7}', value)` extracts the parent id directly, regardless of where (or whether) modifiers/comments appear around it.
- Raises with the offending line if no HPO id is found, so a malformed `is_a:` line surfaces a clear error instead of silently storing garbage as `parent_id` (which is what bit us in the last PR).
- `update_hpo_tests.py` — added a new fixture term `HP:9999003` using the OBO 1.4 standard ordering (`{modifier} ! comment`) so this case is covered going forward; bumped record counts to 8.